### PR TITLE
Default FDTD to JAX backend and add CPU benchmark

### DIFF
--- a/beamz/simulation/backends/__init__.py
+++ b/beamz/simulation/backends/__init__.py
@@ -5,35 +5,72 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def get_backend(name="numpy", **kwargs):
-    """Select the backend."""
+
+def _load_numpy_backend(**kwargs):
+    from beamz.simulation.backends.numpy_backend import NumPyBackend
+
+    return NumPyBackend(**kwargs)
+
+
+def _load_jax_backend(**kwargs):
+    try:
+        import jax  # noqa: F401  # Lazy import to detect availability
+    except ImportError as exc:  # pragma: no cover - handled by caller
+        raise ImportError("JAX backend requested but JAX is not installed") from exc
+
+    from beamz.simulation.backends.jax_backend import JAXBackend
+
+    return JAXBackend(**kwargs)
+
+
+def get_backend(name="auto", **kwargs):
+    """Select the backend used for FDTD simulations.
+
+    Parameters
+    ----------
+    name:
+        Name of the backend to load. Supported values are ``"jax"``, ``"numpy"`` and
+        ``"torch"``.  When ``"auto"`` (the default) is provided the function attempts to
+        initialise the high-performance JAX backend and falls back to NumPy if JAX is not
+        available.
+    **kwargs:
+        Keyword arguments forwarded to the backend initialiser.
+    """
+
+    if name is None:
+        name = "auto"
+
     name = name.lower()
-        
+
+    if name == "auto":
+        try:
+            return _load_jax_backend(**kwargs)
+        except ImportError as exc:
+            logger.warning("JAX backend unavailable (%s); falling back to NumPy", exc)
+            return _load_numpy_backend(**kwargs)
+
     if name == "numpy":
-        from beamz.simulation.backends.numpy_backend import NumPyBackend
-        return NumPyBackend(**kwargs)
-    
+        return _load_numpy_backend(**kwargs)
+
+    if name == "jax":
+        try:
+            return _load_jax_backend(**kwargs)
+        except ImportError as exc:
+            logger.warning("JAX backend unavailable (%s); falling back to NumPy", exc)
+            return _load_numpy_backend(**kwargs)
+
     if name == "torch":
         try:
-            import torch
+            import torch  # noqa: F401
             from beamz.simulation.backends.torch_backend import TorchBackend
+
             return TorchBackend(**kwargs)
         except ImportError:
             logger.warning("PyTorch not available, falling back to NumPy backend")
-            from beamz.simulation.backends.numpy_backend import NumPyBackend
-            return NumPyBackend(**kwargs)
-    
-    if name == "jax":
-        try:
-            import jax
-            from beamz.simulation.backends.jax_backend import JAXBackend
-            return JAXBackend(**kwargs)
-        except ImportError as e:
-            logger.warning(f"JAX not available ({e}), falling back to NumPy backend")
-            from beamz.simulation.backends.numpy_backend import NumPyBackend
-            return NumPyBackend(**kwargs)
-    
+            return _load_numpy_backend(**kwargs)
+
     raise ValueError(f"Unknown backend: {name}")
 
+
 # Export available backends
-__all__ = ['get_backend']
+__all__ = ["get_backend"]

--- a/beamz/simulation/backends/jax_backend.py
+++ b/beamz/simulation/backends/jax_backend.py
@@ -12,6 +12,8 @@ from beamz.simulation.backends.base import Backend
 class JAXBackend(Backend):
     """High-performance JAX backend for FDTD with JIT compilation and multi-device support."""
 
+    backend_name = "jax"
+
     def __init__(self, device="auto", **kwargs):
         super().__init__()
         
@@ -97,21 +99,44 @@ class JAXBackend(Backend):
             self.update_e_field_compiled = self._update_e_field_core
             self.update_fields_fused_compiled = self._update_fields_fused
 
+    def _resolve_dtype(self, dtype):
+        resolved = dtype if dtype is not None else self.dtype
+        if not self.use_64bit:
+            if resolved in (np.float64, jnp.float64):
+                resolved = jnp.float32
+            elif resolved in (np.complex128, jnp.complex128):
+                resolved = jnp.complex64
+        return resolved
+
     def zeros(self, shape, dtype=None):
         """Create an array of zeros with the given shape and optional dtype."""
-        return jnp.zeros(shape, dtype=(dtype if dtype is not None else self.dtype))
-        
+        resolved_dtype = self._resolve_dtype(dtype)
+        return jnp.zeros(shape, dtype=resolved_dtype)
+
     def ones(self, shape, dtype=None):
         """Create an array of ones with the given shape and optional dtype."""
-        return jnp.ones(shape, dtype=(dtype if dtype is not None else self.dtype))
+        resolved_dtype = self._resolve_dtype(dtype)
+        return jnp.ones(shape, dtype=resolved_dtype)
         
     def copy(self, array):
         """Create a copy of the array."""
         return jnp.array(array)
 
     def from_numpy(self, arr):
-        """Convert NumPy array to JAX array."""
-        return jnp.asarray(arr, dtype=self.dtype)
+        """Convert NumPy array to a JAX array while preserving meaningful dtypes."""
+        jax_array = jnp.asarray(arr)
+
+        target_np_dtype = np.dtype(self.dtype)
+        if (jax_array.dtype != self.dtype and
+                np.issubdtype(jax_array.dtype, np.floating) and
+                np.issubdtype(target_np_dtype, np.floating)):
+            jax_array = jax_array.astype(self.dtype)
+        elif (jax_array.dtype != self.dtype and
+              np.issubdtype(jax_array.dtype, np.complexfloating) and
+              np.issubdtype(target_np_dtype, np.complexfloating)):
+            jax_array = jax_array.astype(self.dtype)
+
+        return jax_array
 
     def to_numpy(self, arr):
         """Convert JAX array to NumPy array."""

--- a/beamz/simulation/backends/numpy_backend.py
+++ b/beamz/simulation/backends/numpy_backend.py
@@ -3,6 +3,8 @@ from beamz.simulation.backends.base import Backend
 
 class NumPyBackend(Backend):
     """NumPy backend for FDTD computations."""
+
+    backend_name = "numpy"
     def __init__(self, **kwargs):
         """Initialize NumPy backend."""
         pass

--- a/beamz/simulation/fdtd.py
+++ b/beamz/simulation/fdtd.py
@@ -18,7 +18,8 @@ class FDTD:
     - 2D: TE-polarized (Ez, Hx, Hy fields)
     - 3D: Full Maxwell equations (Ex, Ey, Ez, Hx, Hy, Hz fields)
     """
-    def __init__(self, design, time, mesh: str = "regular", resolution: float = 0.02*µm, backend="numpy", backend_options=None):
+    def __init__(self, design, time, mesh: str = "regular", resolution: float = 0.02*µm,
+                 backend="auto", backend_options=None):
         # Initialize the design and detect dimensionality
         self.design = design
         self.resolution = resolution
@@ -50,7 +51,13 @@ class FDTD:
         
         # Initialize the backend
         backend_options = backend_options or {}
-        self.backend = get_backend(name=backend, **backend_options)
+        requested_backend = backend or "auto"
+        if self.is_3d and requested_backend in ("auto", "jax"):
+            display_status("JAX backend currently supports only 2D FDTD; falling back to NumPy for 3D simulations.",
+                           "warning")
+            requested_backend = "numpy"
+
+        self.backend = get_backend(name=requested_backend, **backend_options)
         
         # Initialize fields based on dimensionality
         self._init_fields()

--- a/beamz/simulation/helper.py
+++ b/beamz/simulation/helper.py
@@ -4,6 +4,9 @@ from beamz.design.sources import ModeSource, GaussianSource
 
 def apply_sources(fdtd) -> None:
     """Apply all sources for the current time step to fdtd fields."""
+    backend_name = getattr(fdtd.backend, "backend_name", "numpy")
+    is_jax_backend = backend_name == "jax"
+
     for source in fdtd.sources:
         if isinstance(source, ModeSource):
             mode_profile = source.mode_profiles[0]
@@ -35,19 +38,71 @@ def apply_sources(fdtd) -> None:
                     source_value = amplitude * modulation
 
                 if fdtd.is_3d:
-                    fdtd.Ez[z_target, y, x] += source_value
-                    if source.direction == "+x" and x > 0: fdtd.Ez[z_target, y, x-1] = 0
-                    elif source.direction == "-x" and x < fdtd.nx-1: fdtd.Ez[z_target, y, x+1] = 0
-                    elif source.direction == "+y" and y > 0: fdtd.Ez[z_target, y-1, x] = 0
-                    elif source.direction == "-y" and y < fdtd.ny-1: fdtd.Ez[z_target, y+1, x] = 0
-                    elif source.direction == "+z" and z_target > 0: fdtd.Ez[z_target-1, y, x] = 0
-                    elif source.direction == "-z" and z_target < fdtd.Ez.shape[0]-1: fdtd.Ez[z_target+1, y, x] = 0
+                    value = fdtd.Ez.dtype.type(source_value)
+                    if is_jax_backend:
+                        fdtd.Ez = fdtd.Ez.at[z_target, y, x].add(value)
+                    else:
+                        fdtd.Ez[z_target, y, x] += value
+
+                    zero_val = fdtd.Ez.dtype.type(0)
+                    if source.direction == "+x" and x > 0:
+                        if is_jax_backend:
+                            fdtd.Ez = fdtd.Ez.at[z_target, y, x-1].set(zero_val)
+                        else:
+                            fdtd.Ez[z_target, y, x-1] = zero_val
+                    elif source.direction == "-x" and x < fdtd.nx-1:
+                        if is_jax_backend:
+                            fdtd.Ez = fdtd.Ez.at[z_target, y, x+1].set(zero_val)
+                        else:
+                            fdtd.Ez[z_target, y, x+1] = zero_val
+                    elif source.direction == "+y" and y > 0:
+                        if is_jax_backend:
+                            fdtd.Ez = fdtd.Ez.at[z_target, y-1, x].set(zero_val)
+                        else:
+                            fdtd.Ez[z_target, y-1, x] = zero_val
+                    elif source.direction == "-y" and y < fdtd.ny-1:
+                        if is_jax_backend:
+                            fdtd.Ez = fdtd.Ez.at[z_target, y+1, x].set(zero_val)
+                        else:
+                            fdtd.Ez[z_target, y+1, x] = zero_val
+                    elif source.direction == "+z" and z_target > 0:
+                        if is_jax_backend:
+                            fdtd.Ez = fdtd.Ez.at[z_target-1, y, x].set(zero_val)
+                        else:
+                            fdtd.Ez[z_target-1, y, x] = zero_val
+                    elif source.direction == "-z" and z_target < fdtd.Ez.shape[0]-1:
+                        if is_jax_backend:
+                            fdtd.Ez = fdtd.Ez.at[z_target+1, y, x].set(zero_val)
+                        else:
+                            fdtd.Ez[z_target+1, y, x] = zero_val
                 else:
-                    fdtd.Ez[y, x] += source_value
-                    if source.direction == "+x" and x > 0: fdtd.Ez[y, x-1] = 0
-                    elif source.direction == "-x" and x < fdtd.nx-1: fdtd.Ez[y, x+1] = 0
-                    elif source.direction == "+y" and y > 0: fdtd.Ez[y-1, x] = 0
-                    elif source.direction == "-y" and y < fdtd.ny-1: fdtd.Ez[y+1, x] = 0
+                    value = fdtd.Ez.dtype.type(source_value)
+                    if is_jax_backend:
+                        fdtd.Ez = fdtd.Ez.at[y, x].add(value)
+                    else:
+                        fdtd.Ez[y, x] += value
+
+                    zero_val = fdtd.Ez.dtype.type(0)
+                    if source.direction == "+x" and x > 0:
+                        if is_jax_backend:
+                            fdtd.Ez = fdtd.Ez.at[y, x-1].set(zero_val)
+                        else:
+                            fdtd.Ez[y, x-1] = zero_val
+                    elif source.direction == "-x" and x < fdtd.nx-1:
+                        if is_jax_backend:
+                            fdtd.Ez = fdtd.Ez.at[y, x+1].set(zero_val)
+                        else:
+                            fdtd.Ez[y, x+1] = zero_val
+                    elif source.direction == "+y" and y > 0:
+                        if is_jax_backend:
+                            fdtd.Ez = fdtd.Ez.at[y-1, x].set(zero_val)
+                        else:
+                            fdtd.Ez[y-1, x] = zero_val
+                    elif source.direction == "-y" and y < fdtd.ny-1:
+                        if is_jax_backend:
+                            fdtd.Ez = fdtd.Ez.at[y+1, x].set(zero_val)
+                        else:
+                            fdtd.Ez[y+1, x] = zero_val
 
         elif isinstance(source, GaussianSource):
             modulation = source.signal[fdtd.current_step]
@@ -88,7 +143,14 @@ def apply_sources(fdtd) -> None:
                 gaussian_amp = np.exp(exponent)
                 gaussian_amp = fdtd.backend.from_numpy(gaussian_amp)
                 z_ez_idx = max(0, min(fdtd.Ez.shape[0]-1, z_start))
-                fdtd.Ez[z_ez_idx:z_ez_idx + (z_end - z_start), y_start:y_end, x_start:x_end] += gaussian_amp[:(z_end - z_start), :, :] * modulation
+                z_slice = slice(z_ez_idx, z_ez_idx + (z_end - z_start))
+                y_slice = slice(y_start, y_end)
+                x_slice = slice(x_start, x_end)
+                increment = (gaussian_amp[:(z_end - z_start), :, :] * modulation).astype(fdtd.Ez.dtype)
+                if is_jax_backend:
+                    fdtd.Ez = fdtd.Ez.at[z_slice, y_slice, x_slice].add(increment)
+                else:
+                    fdtd.Ez[z_slice, y_slice, x_slice] += increment
             else:
                 width_x_grid = width_phys / fdtd.dx
                 width_y_grid = width_phys / fdtd.dy
@@ -111,7 +173,11 @@ def apply_sources(fdtd) -> None:
                 exponent = -(dist_x_sq / (2 * sigma_x_sq) + dist_y_sq / (2 * sigma_y_sq))
                 gaussian_amp = np.exp(exponent) / 4
                 gaussian_amp = fdtd.backend.from_numpy(gaussian_amp)
-                fdtd.Ez[y_start:y_end, x_start:x_end] += gaussian_amp * modulation
+                increment = (gaussian_amp * modulation).astype(fdtd.Ez.dtype)
+                if is_jax_backend:
+                    fdtd.Ez = fdtd.Ez.at[y_start:y_end, x_start:x_end].add(increment)
+                else:
+                    fdtd.Ez[y_start:y_end, x_start:x_end] += increment
 
 def accumulate_power(fdtd) -> None:
     """Accumulate power for current step if requested (updates fdtd.power_accumulated)."""

--- a/examples/backend_benchmark.py
+++ b/examples/backend_benchmark.py
@@ -1,0 +1,83 @@
+"""Benchmark the NumPy and JAX backends on a simple 2D FDTD update loop."""
+import pathlib
+import sys
+import time
+from dataclasses import dataclass
+
+import numpy as np
+
+# Allow running the script directly without installing the package.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from beamz.const import EPS_0, MU_0, LIGHT_SPEED
+from beamz.simulation.backends import get_backend
+
+
+@dataclass
+class BenchmarkResult:
+    backend: str
+    mean_step_time: float
+    total_time: float
+    steps: int
+
+
+def _create_backend(name: str):
+    if name == "jax":
+        # Force CPU execution to provide a fair comparison with NumPy.
+        return get_backend("jax", device="cpu", use_jit=True)
+    if name == "numpy":
+        return get_backend("numpy")
+    raise ValueError(f"Unsupported backend for benchmark: {name}")
+
+
+def _block_until_ready(*arrays):
+    for arr in arrays:
+        block = getattr(arr, "block_until_ready", None)
+        if callable(block):
+            block()
+
+
+def benchmark_backend(name: str, steps: int = 200, shape=(256, 256)) -> BenchmarkResult:
+    backend = _create_backend(name)
+    ny, nx = shape
+    dx = dy = 0.02e-6
+    dt = 0.99 * dx / (LIGHT_SPEED * np.sqrt(2))
+
+    Ez = backend.zeros((ny, nx), dtype=np.complex128)
+    Hx = backend.zeros((ny, nx - 1), dtype=np.complex128)
+    Hy = backend.zeros((ny - 1, nx), dtype=np.complex128)
+
+    sigma = backend.from_numpy(np.zeros((ny, nx), dtype=np.float32))
+    eps_r = backend.from_numpy(np.ones((ny, nx), dtype=np.float32))
+
+    # Warm up the kernels (especially important for JAX's JIT compilation).
+    warmup_steps = 5
+    for _ in range(warmup_steps):
+        Hx, Hy = backend.update_h_fields(Hx, Hy, Ez, sigma, dx, dy, dt, MU_0, EPS_0)
+        Ez = backend.update_e_field(Ez, Hx, Hy, sigma, eps_r, dx, dy, dt, EPS_0)
+    _block_until_ready(Ez, Hx, Hy)
+
+    start = time.perf_counter()
+    for _ in range(steps):
+        Hx, Hy = backend.update_h_fields(Hx, Hy, Ez, sigma, dx, dy, dt, MU_0, EPS_0)
+        Ez = backend.update_e_field(Ez, Hx, Hy, sigma, eps_r, dx, dy, dt, EPS_0)
+    _block_until_ready(Ez, Hx, Hy)
+    end = time.perf_counter()
+
+    total_time = end - start
+    mean_step_time = total_time / steps
+    return BenchmarkResult(name, mean_step_time, total_time, steps)
+
+
+def main():
+    print("Comparing backends on CPU…")
+    for backend_name in ("jax", "numpy"):
+        result = benchmark_backend(backend_name)
+        print(f"{result.backend:>5} :: mean step {result.mean_step_time*1e6:8.2f} µs"
+              f" (total {result.total_time:.3f} s over {result.steps} steps)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- default FDTD backend selection now prefers JAX and falls back to NumPy when required
- update field source application and JAX backend utilities to operate safely with immutable arrays and dtype constraints
- add a CPU benchmark example comparing NumPy and JAX backend performance

## Testing
- python examples/backend_benchmark.py

------
https://chatgpt.com/codex/tasks/task_e_68dd06b46de88326a8188bff963add9c