### PR TITLE
[Refactor]: Split devices from the design and clearly import monitors and sources into the simualtion

### DIFF
--- a/beamz/__init__.py
+++ b/beamz/__init__.py
@@ -51,7 +51,7 @@ from beamz.simulation.compiled import (
     RunState,
     compile_simulation,
 )
-from beamz.simulation.core import PortSpec, Simulation
+from beamz.simulation.core import MonitorResults, PortSpec, Simulation, SimulationResults
 
 # Import UI helpers
 from beamz.visual.helpers import (
@@ -102,6 +102,8 @@ _exports = {
     "RegularGrid": RegularGrid,
     "Simulation": Simulation,
     "PortSpec": PortSpec,
+    "MonitorResults": MonitorResults,
+    "SimulationResults": SimulationResults,
     "CompiledRunConfig": CompiledRunConfig,
     "CompiledSimulation": CompiledSimulation,
     "EngineState": EngineState,

--- a/beamz/design/core.py
+++ b/beamz/design/core.py
@@ -431,7 +431,7 @@ class Design:
             depth=depth,
             material=material,
         )
-        self.structures, self.sources, self.monitors = [background], [], []
+        self.structures = [background]
         self.width, self.height, self.depth, self.time = width, height, depth, 0
         self.is_3d = depth is not None and depth > 0
         self.layers: dict[int, list[Polygon]] = {}
@@ -459,20 +459,26 @@ class Design:
         return True
 
     def add(self, structure: type[Polygon]):
-        """Add structure to the design and update 3D flag if needed."""
+        """Add a geometric structure to the design and update 3D state."""
         from beamz.devices.monitors import Monitor
         from beamz.devices.sources import GaussianSource, ModeSource
+
+        if isinstance(structure, Monitor):
+            raise TypeError(
+                "Design only accepts geometry. Pass monitors to "
+                "Simulation(monitors=[...]) instead."
+            )
+        if isinstance(structure, (ModeSource, GaussianSource)):
+            raise TypeError(
+                "Design only accepts geometry. Pass sources to "
+                "Simulation(sources=[...]) instead."
+            )
 
         # Set back-reference to design if the structure supports it
         if hasattr(structure, "design"):
             structure.design = self
 
-        if isinstance(structure, Monitor):
-            self.monitors.append(structure)
-        elif isinstance(structure, (ModeSource, GaussianSource)):
-            self.sources.append(structure)
-        else:
-            self.structures.append(structure)
+        self.structures.append(structure)
 
         if hasattr(structure, "is_3d") and structure.is_3d:
             self.is_3d = True
@@ -703,7 +709,7 @@ class Design:
             depth=self.depth,
             material=background_material,
         )
-        new_design.structures, new_design.sources, new_design.monitors = [], [], []
+        new_design.structures = []
 
         # Copy structures
         for structure in self.structures:
@@ -720,26 +726,6 @@ class Design:
                 new_design.structures.append(copied_structure)
             else:
                 new_design.structures.append(structure)
-
-        # Copy sources
-        for source in self.sources:
-            if hasattr(source, "copy"):
-                copied_source = source.copy()
-                if hasattr(copied_source, "design"):
-                    copied_source.design = new_design
-                new_design.sources.append(copied_source)
-            else:
-                new_design.sources.append(source)
-
-        # Copy monitors
-        for monitor in self.monitors:
-            if hasattr(monitor, "copy"):
-                copied_monitor = monitor.copy()
-                if hasattr(copied_monitor, "design"):
-                    copied_monitor.design = new_design
-                new_design.monitors.append(copied_monitor)
-            else:
-                new_design.monitors.append(monitor)
 
         new_design.is_3d, new_design.depth, new_design.time = (
             self.is_3d,

--- a/beamz/devices/monitors/compiler.py
+++ b/beamz/devices/monitors/compiler.py
@@ -270,7 +270,7 @@ def _compile_monitor_3d_indices(
 
 
 def compile_monitor_specs(
-    devices: list,
+    monitors: list,
     fields,
     resolution: float,
     num_steps: int,
@@ -285,7 +285,6 @@ def compile_monitor_specs(
     max_records:
         Maximum number of records per monitor row in monitor-state buffers.
     """
-    monitors = [d for d in devices if isinstance(d, Monitor)]
     if not monitors:
         return tuple(), 0
 

--- a/beamz/devices/monitors/monitors.py
+++ b/beamz/devices/monitors/monitors.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from typing import Callable, Optional
 
 import matplotlib.pyplot as plt
@@ -8,7 +9,94 @@ from matplotlib.patches import Rectangle as MatplotlibRectangle
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class _MonitorState:
+    """Mutable runtime state kept separate from Monitor configuration."""
+
+    fields: dict[str, list]
+    frequency_flux_spectrum: np.ndarray
+    objective_value: Optional[float]
+    power_accumulated: np.ndarray | None
+    energy_history: list
+    power_history: list
+    power_timestamps: list
+    power_accumulation_count: int
+    step_count: int
+    last_record_step: int
+    _dft_accum: dict
+    _dft_weight_sum: np.ndarray
+    _dft_sample_count: int
+    _dft_phase: np.ndarray
+    _dft_last_t: float | None
+    _dft_last_dt: float | None
+    _dft_last_rot: np.ndarray | None
+
+    @classmethod
+    def create(cls, *, dft_frequencies: np.ndarray, frequency_points: np.ndarray):
+        fields = {
+            "Ex": [],
+            "Ey": [],
+            "Ez": [],
+            "Hx": [],
+            "Hy": [],
+            "Hz": [],
+            "t": [],
+        }
+        return cls(
+            fields=fields,
+            frequency_flux_spectrum=np.zeros(
+                frequency_points.shape, dtype=np.complex64
+            ),
+            objective_value=None,
+            power_accumulated=None,
+            energy_history=[],
+            power_history=[],
+            power_timestamps=[],
+            power_accumulation_count=0,
+            step_count=0,
+            last_record_step=-1,
+            _dft_accum={},
+            _dft_weight_sum=np.zeros(dft_frequencies.size, dtype=float),
+            _dft_sample_count=0,
+            _dft_phase=np.ones(dft_frequencies.size, dtype=np.complex128),
+            _dft_last_t=None,
+            _dft_last_dt=None,
+            _dft_last_rot=None,
+        )
+
+
 class Monitor:
+    _RUNTIME_ATTRS = {
+        "fields",
+        "frequency_flux_spectrum",
+        "objective_value",
+        "power_accumulated",
+        "energy_history",
+        "power_history",
+        "power_timestamps",
+        "power_accumulation_count",
+        "step_count",
+        "last_record_step",
+        "_dft_accum",
+        "_dft_weight_sum",
+        "_dft_sample_count",
+        "_dft_phase",
+        "_dft_last_t",
+        "_dft_last_dt",
+        "_dft_last_rot",
+    }
+
+    def __getattr__(self, name):
+        if name in self._RUNTIME_ATTRS and "_state" in self.__dict__:
+            return getattr(self._state, name)
+        raise AttributeError(f"{type(self).__name__!s} has no attribute {name!r}")
+
+    def __setattr__(self, name, value):
+        if name in self._RUNTIME_ATTRS and "_state" in self.__dict__:
+            setattr(self._state, name, value)
+            return
+        object.__setattr__(self, name, value)
+
     def __init__(
         self,
         design=None,
@@ -84,47 +172,18 @@ class Monitor:
         self.frequency_points = freq_arr
         self.frequency_record_interval = max(1, int(frequency_record_interval))
         self.accumulate_frequency = bool(freq_arr.size > 0)
-        self.frequency_flux_spectrum = np.zeros(freq_arr.shape, dtype=np.complex64)
         self.objective_function = objective_function
-        self.objective_value: Optional[float] = None
         self.name = name
 
         # Determine if this is a 3D monitor based on input parameters
         self.is_3d = self._determine_3d_mode(start, end, design)
 
-        # Initialize field storage
-        if self.is_3d:
-            # 3D fields: Ex, Ey, Ez, Hx, Hy, Hz
-            self.fields = {
-                "Ex": [],
-                "Ey": [],
-                "Ez": [],
-                "Hx": [],
-                "Hy": [],
-                "Hz": [],
-                "t": [],
-            }
-        else:
-            # 2D fields: Ez, Hx, Hy and optional TE set Ex, Ey, Hz
-            self.fields = {
-                "Ex": [],
-                "Ey": [],
-                "Ez": [],
-                "Hx": [],
-                "Hy": [],
-                "Hz": [],
-                "t": [],
-            }
+        # Runtime recording state is kept separate from the monitor spec.
+        self._state = _MonitorState.create(
+            dft_frequencies=self.dft_frequencies,
+            frequency_points=self.frequency_points,
+        )
 
-        # Power and energy storage
-        self.power_accumulated = None
-        self.energy_history = []
-        self.power_history = []
-        self.power_timestamps = []
-        self.power_accumulation_count = 0
-        # Recording control
-        self.step_count = 0
-        self.last_record_step = -1
         # Live visualization
         self.live_fig = None
         self.live_axes = None
@@ -132,14 +191,6 @@ class Monitor:
         self.update_interval = (
             10  # Update every N records (faster updates for visibility)
         )
-        # DFT accumulators: component -> complex[nf, npoints], plus scalar weight sum.
-        self._dft_accum = {}
-        self._dft_weight_sum = np.zeros(self.dft_frequencies.size, dtype=float)
-        self._dft_sample_count = 0
-        self._dft_phase = np.ones(self.dft_frequencies.size, dtype=np.complex128)
-        self._dft_last_t = None
-        self._dft_last_dt = None
-        self._dft_last_rot = None
 
         if self.is_3d:
             self._init_3d_monitor(start, end, plane_normal, plane_position, size)

--- a/beamz/devices/sources/compiler.py
+++ b/beamz/devices/sources/compiler.py
@@ -195,7 +195,7 @@ def _mode_3d_profiles_and_indices(src: ModeSource):
 
 
 def compile_source_specs(
-    devices: list,
+    sources: list,
     fields,
     dt: float,
     resolution: float,
@@ -209,7 +209,7 @@ def compile_source_specs(
     """
     specs: list[CompiledSourceSpec] = []
 
-    for device in devices:
+    for device in sources:
         if isinstance(device, GaussianSource):
             specs.extend(
                 _compile_gaussian_source(

--- a/beamz/devices/sources/gaussian.py
+++ b/beamz/devices/sources/gaussian.py
@@ -1,7 +1,17 @@
+from dataclasses import dataclass
+
 import jax.numpy as jnp
 import numpy as np
 
 from beamz.const import EPS_0
+
+
+@dataclass
+class _GaussianSourceState:
+    """Mutable prepared state for GaussianSource."""
+
+    _spatial_profile_ez: jnp.ndarray | None = None
+    _grid_indices: tuple[slice, ...] | tuple[slice, slice] | None = None
 
 
 class GaussianSource:
@@ -12,6 +22,19 @@ class GaussianSource:
 
     Supports JAX differentiability through position and width parameters.
     """
+
+    _RUNTIME_ATTRS = {"_spatial_profile_ez", "_grid_indices"}
+
+    def __getattr__(self, name):
+        if name in self._RUNTIME_ATTRS and "_state" in self.__dict__:
+            return getattr(self._state, name)
+        raise AttributeError(f"{type(self).__name__!s} has no attribute {name!r}")
+
+    def __setattr__(self, name, value):
+        if name in self._RUNTIME_ATTRS and "_state" in self.__dict__:
+            setattr(self._state, name, value)
+            return
+        object.__setattr__(self, name, value)
 
     def __init__(self, position, width, signal):
         """Initialize the Gaussian source.
@@ -28,8 +51,7 @@ class GaussianSource:
             self.signal = jnp.asarray(signal)
         else:
             self.signal = signal
-        self._spatial_profile_ez = None
-        self._grid_indices = None
+        self._state = _GaussianSourceState()
 
     def _get_signal_value(self, time, dt):
         """Interpolate signal value at arbitrary time (JAX-compatible)."""

--- a/beamz/devices/sources/mode.py
+++ b/beamz/devices/sources/mode.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 
 import jax.numpy as jnp
 import numpy as np
@@ -9,6 +10,40 @@ from beamz.devices.sources.solve import solve_modes
 logger = logging.getLogger(__name__)
 
 _VALID_DIRECTIONS = {"+x", "-x", "+y", "-y", "+z", "-z"}
+
+
+@dataclass
+class _ModeSourceState:
+    """Mutable prepared state for ModeSource."""
+
+    _Ex_profile: np.ndarray | None = None
+    _Ey_profile: np.ndarray | None = None
+    _Ez_profile: np.ndarray | None = None
+    _Hx_profile: np.ndarray | None = None
+    _Hy_profile: np.ndarray | None = None
+    _Hz_profile: np.ndarray | None = None
+    _Ex_indices: tuple | None = None
+    _Ey_indices: tuple | None = None
+    _Ez_indices: tuple | None = None
+    _Hx_indices: tuple | None = None
+    _Hy_indices: tuple | None = None
+    _Hz_indices: tuple | None = None
+    _jz_profile: np.ndarray | None = None
+    _my_profile: np.ndarray | None = None
+    _mz_profile: np.ndarray | None = None
+    _jy_profile: np.ndarray | None = None
+    _jx_profile: np.ndarray | None = None
+    _ez_indices: tuple | None = None
+    _h_indices: tuple | None = None
+    _hz_indices: tuple | None = None
+    _e_indices: tuple | None = None
+    _h_component: str | None = None
+    _e_component: str | None = None
+    _neff: float | None = None
+    _impedance_neff: float | None = None
+    _dt_physical: float = 0.0
+    _launch_dt: float | None = None
+    _initialized: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -1270,6 +1305,57 @@ class ModeSource:
     mode injection, accounting for proper Yee grid staggering.
     """
 
+    _RUNTIME_ATTRS = {
+        "_Ex_profile",
+        "_Ey_profile",
+        "_Ez_profile",
+        "_Hx_profile",
+        "_Hy_profile",
+        "_Hz_profile",
+        "_Ex_indices",
+        "_Ey_indices",
+        "_Ez_indices",
+        "_Hx_indices",
+        "_Hy_indices",
+        "_Hz_indices",
+        "_jz_profile",
+        "_my_profile",
+        "_mz_profile",
+        "_jy_profile",
+        "_jx_profile",
+        "_ez_indices",
+        "_h_indices",
+        "_hz_indices",
+        "_e_indices",
+        "_h_component",
+        "_e_component",
+        "_neff",
+        "_impedance_neff",
+        "_dt_physical",
+        "_launch_dt",
+        "_initialized",
+        "_resolution",
+        "_is_3d",
+        "_grid_shape",
+        "_axis",
+        "_eps_profile_2d",
+        "_y_start",
+        "_y_end",
+        "_x_start",
+        "_x_end",
+    }
+
+    def __getattr__(self, name):
+        if name in self._RUNTIME_ATTRS and "_state" in self.__dict__:
+            return getattr(self._state, name)
+        raise AttributeError(f"{type(self).__name__!s} has no attribute {name!r}")
+
+    def __setattr__(self, name, value):
+        if name in self._RUNTIME_ATTRS and "_state" in self.__dict__:
+            setattr(self._state, name, value)
+            return
+        object.__setattr__(self, name, value)
+
     def __init__(
         self, grid, center, width, wavelength, pol, signal, direction="+x", height=None
     ):
@@ -1287,41 +1373,7 @@ class ModeSource:
         self.direction, self._direction_axis, self._direction_sign = _parse_direction(
             direction
         )
-
-        # Storage for all 6 field component profiles (for 3D injection)
-        self._Ex_profile = None
-        self._Ey_profile = None
-        self._Ez_profile = None
-        self._Hx_profile = None
-        self._Hy_profile = None
-        self._Hz_profile = None
-
-        # Indices for each component's injection position
-        self._Ex_indices = None
-        self._Ey_indices = None
-        self._Ez_indices = None
-        self._Hx_indices = None
-        self._Hy_indices = None
-        self._Hz_indices = None
-
-        # Legacy attributes for compatibility and 2D
-        self._jz_profile = None
-        self._my_profile = None
-        self._mz_profile = None
-        self._jy_profile = None
-        self._jx_profile = None
-        self._ez_indices = None
-        self._h_indices = None
-        self._hz_indices = None
-        self._e_indices = None
-
-        self._h_component = None
-        self._e_component = None
-        self._neff = None
-        self._impedance_neff = None
-        self._dt_physical = 0.0
-        self._launch_dt = None
-        self._initialized = False
+        self._state = _ModeSourceState()
 
     def initialize(self, permittivity, resolution, dt=None):
         """Compute the mode and set up the source currents for all 6 components in 3D."""

--- a/beamz/simulation/__init__.py
+++ b/beamz/simulation/__init__.py
@@ -11,12 +11,14 @@ from beamz.simulation.compiled import (
     RunState,
     compile_simulation,
 )
-from beamz.simulation.core import PortSpec, Simulation
+from beamz.simulation.core import MonitorResults, PortSpec, Simulation, SimulationResults
 
 __all__ = [
     "RegularGrid",
     "Simulation",
     "PortSpec",
+    "MonitorResults",
+    "SimulationResults",
     "CompiledRunConfig",
     "CompiledSimulation",
     "EngineState",

--- a/beamz/simulation/compiled.py
+++ b/beamz/simulation/compiled.py
@@ -1394,8 +1394,8 @@ def _lossy_fraction(
     return float(full_mask.mean())
 
 
-def compile_simulation(design, devices, boundaries, run_cfg) -> CompiledSimulation:
-    """Build a CompiledSimulation from design/devices/boundaries and a run config.
+def compile_simulation(design, sources, monitors, boundaries, run_cfg) -> CompiledSimulation:
+    """Build a CompiledSimulation from design/sources/monitors/boundaries and a run config.
 
     Required run_cfg attributes:
     - fields
@@ -1418,7 +1418,7 @@ def compile_simulation(design, devices, boundaries, run_cfg) -> CompiledSimulati
     t0 = float(getattr(run_cfg, "t0", 0.0))
 
     source_specs = compile_source_specs(
-        devices=devices,
+        sources=sources,
         fields=fields,
         dt=dt,
         resolution=resolution,
@@ -1428,14 +1428,14 @@ def compile_simulation(design, devices, boundaries, run_cfg) -> CompiledSimulati
     )
 
     monitor_specs, _ = compile_monitor_specs(
-        devices=devices,
+        monitors=monitors,
         fields=fields,
         resolution=resolution,
         num_steps=num_steps,
         dt=dt,
     )
 
-    monitor_devices = tuple(d for d in devices if isinstance(d, Monitor))
+    monitor_devices = tuple(monitors)
 
     loop_kind_raw = (
         str(

--- a/beamz/simulation/core.py
+++ b/beamz/simulation/core.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import Literal
@@ -47,6 +48,8 @@ class Simulation:
         self,
         design: Design = None,
         devices: list = None,
+        sources: list = None,
+        monitors: list[Monitor] = None,
         boundaries: list[Boundary] = None,
         thermal=None,
         resolution: float = 0.02 * µm,
@@ -55,12 +58,20 @@ class Simulation:
     ):
         self.design = design
         devices = devices or []
+        sources = sources or []
+        monitors = monitors or []
         boundaries = boundaries or []
         self.resolution = resolution
         self.is_3d = design.is_3d and design.depth > 0
         self.plane_2d = plane_2d.lower()
         if self.plane_2d not in ["xy", "yz", "xz"]:
             self.plane_2d = "xy"
+        self.sources, self.monitors, self.devices = self._normalize_devices(
+            design=design,
+            devices=devices,
+            sources=sources,
+            monitors=monitors,
+        )
 
         # Get material grids from design (design owns the material grids, we reference them)
         permittivity, conductivity, permeability = design.get_material_grids(resolution)
@@ -115,9 +126,6 @@ class Simulation:
         else:
             self.pml_data = None
 
-        # Store device references (no duplication)
-        self.devices = devices
-
         # Store boundary references (no duplication)
         self.boundaries = boundaries
 
@@ -131,6 +139,56 @@ class Simulation:
         self._compiled_program_signature = None
         self._compiled_program_cache = {}
         self._compiled_monitor_state = None
+
+    @staticmethod
+    def _dedupe_devices(devices):
+        seen = set()
+        ordered = []
+        for device in devices:
+            key = id(device)
+            if key in seen:
+                continue
+            seen.add(key)
+            ordered.append(device)
+        return ordered
+
+    @classmethod
+    def _normalize_devices(cls, *, design, devices, sources, monitors):
+        normalized_sources = list(sources)
+        normalized_monitors = list(monitors)
+        other_devices = []
+
+        for device in devices:
+            if isinstance(device, Monitor):
+                normalized_monitors.append(device)
+            else:
+                if hasattr(device, "inject") or hasattr(device, "inject_h"):
+                    normalized_sources.append(device)
+                else:
+                    other_devices.append(device)
+
+        if (
+            design is not None
+            and not devices
+            and not sources
+            and not monitors
+            and (getattr(design, "sources", None) or getattr(design, "monitors", None))
+        ):
+            warnings.warn(
+                "Passing sources and monitors via Design is deprecated. "
+                "Pass them to Simulation(sources=..., monitors=...) instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            normalized_sources.extend(getattr(design, "sources", ()))
+            normalized_monitors.extend(getattr(design, "monitors", ()))
+
+        normalized_sources = cls._dedupe_devices(normalized_sources)
+        normalized_monitors = cls._dedupe_devices(normalized_monitors)
+        normalized_devices = cls._dedupe_devices(
+            [*normalized_sources, *normalized_monitors, *other_devices]
+        )
+        return normalized_sources, normalized_monitors, normalized_devices
 
     def step(self):
         """Perform one FDTD time step with correct Huygens source timing.

--- a/beamz/simulation/core.py
+++ b/beamz/simulation/core.py
@@ -250,6 +250,28 @@ class Simulation:
 
         normalized_sources = cls._dedupe_devices(normalized_sources)
         normalized_monitors = cls._dedupe_devices(normalized_monitors)
+        duplicate_monitor_names = sorted(
+            {
+                str(name)
+                for name in (
+                    getattr(monitor, "name", None) for monitor in normalized_monitors
+                )
+                if name
+                and sum(
+                    1
+                    for monitor in normalized_monitors
+                    if getattr(monitor, "name", None) == name
+                )
+                > 1
+            }
+        )
+        if duplicate_monitor_names:
+            names = ", ".join(duplicate_monitor_names)
+            raise ValueError(
+                "Simulation._normalize_specs found duplicate Monitor.name values: "
+                f"{names}. Monitor names must be unique because PortSpec.monitor_name "
+                "resolution depends on them."
+            )
         return normalized_sources, normalized_monitors
 
     def step(self):

--- a/beamz/simulation/core.py
+++ b/beamz/simulation/core.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -248,21 +247,6 @@ class Simulation:
     def _normalize_specs(cls, *, design, sources, monitors):
         normalized_sources = list(sources)
         normalized_monitors = list(monitors)
-
-        if (
-            design is not None
-            and not sources
-            and not monitors
-            and (getattr(design, "sources", None) or getattr(design, "monitors", None))
-        ):
-            warnings.warn(
-                "Passing sources and monitors via Design is deprecated. "
-                "Pass them to Simulation(sources=..., monitors=...) instead.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-            normalized_sources.extend(getattr(design, "sources", ()))
-            normalized_monitors.extend(getattr(design, "monitors", ()))
 
         normalized_sources = cls._dedupe_devices(normalized_sources)
         normalized_monitors = cls._dedupe_devices(normalized_monitors)

--- a/beamz/simulation/core.py
+++ b/beamz/simulation/core.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import os
 import warnings
+from collections.abc import Mapping
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Literal
+from typing import Any, Literal
 
 import jax
 import jax.numpy as jnp
@@ -39,6 +42,98 @@ class PortSpec:
     reference_monitor: str | None = None
     incident_wave: Literal["plus", "minus", "auto"] = "plus"
     scattered_wave: Literal["plus", "minus", "auto"] = "minus"
+
+
+@dataclass(frozen=True)
+class MonitorResults:
+    """Snapshot of one monitor's recorded outputs."""
+
+    monitor: Monitor
+    fields: dict[str, tuple[Any, ...]]
+    power_history: np.ndarray
+    power_timestamps: np.ndarray
+    frequency_flux_spectrum: np.ndarray
+    objective_value: float | None = None
+
+    @classmethod
+    def from_monitor(cls, monitor: Monitor) -> "MonitorResults":
+        fields = {
+            name: tuple(values)
+            for name, values in getattr(monitor, "fields", {}).items()
+        }
+        return cls(
+            monitor=monitor,
+            fields=fields,
+            power_history=np.asarray(getattr(monitor, "power_history", ()), dtype=float),
+            power_timestamps=np.asarray(
+                getattr(monitor, "power_timestamps", ()), dtype=float
+            ),
+            frequency_flux_spectrum=np.asarray(
+                getattr(monitor, "frequency_flux_spectrum", ()), dtype=np.complex64
+            ),
+            objective_value=getattr(monitor, "objective_value", None),
+        )
+
+
+@dataclass(frozen=True)
+class SimulationResults(Mapping[str, Any]):
+    """Primary run output with backward-compatible mapping access."""
+
+    simulation: "Simulation"
+    fields: dict[str, np.ndarray] | None = None
+    monitors: tuple[Monitor, ...] = ()
+    monitor_results: dict[str, MonitorResults] | None = None
+    animation: Any = None
+
+    def __getitem__(self, key: str) -> Any:
+        payload = self.to_dict()
+        if key not in payload:
+            raise KeyError(key)
+        return payload[key]
+
+    def __iter__(self):
+        return iter(self.to_dict())
+
+    def __len__(self) -> int:
+        return len(self.to_dict())
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {}
+        if self.fields is not None:
+            payload["fields"] = self.fields
+        if self.monitors:
+            payload["monitors"] = list(self.monitors)
+        if self.monitor_results:
+            payload["monitor_results"] = self.monitor_results
+        if self.animation is not None:
+            payload["animation"] = self.animation
+        return payload
+
+    @classmethod
+    def from_run(
+        cls,
+        simulation: "Simulation",
+        *,
+        fields: dict[str, np.ndarray] | None = None,
+        monitors: list[Monitor] | tuple[Monitor, ...] = (),
+        animation: Any = None,
+    ) -> "SimulationResults" | None:
+        monitor_tuple = tuple(monitors)
+        monitor_results = {
+            getattr(monitor, "name", None) or f"monitor_{idx}": MonitorResults.from_monitor(
+                monitor
+            )
+            for idx, monitor in enumerate(monitor_tuple)
+        }
+        if fields is None and not monitor_tuple and animation is None:
+            return None
+        return cls(
+            simulation=simulation,
+            fields=fields,
+            monitors=monitor_tuple,
+            monitor_results=monitor_results or None,
+            animation=animation,
+        )
 
 
 class Simulation:
@@ -736,16 +831,17 @@ class Simulation:
         if monitor_state is not None:
             program.apply_monitor_state(monitor_state)
 
-        result = {}
+        fields_result = None
         if field_history is not None:
-            result["fields"] = {
+            fields_result = {
                 k: np.stack(v) if len(v) > 0 else np.zeros((0,))
                 for k, v in field_history.items()
             }
-        monitors = [device for device in self.devices if isinstance(device, Monitor)]
-        if monitors:
-            result["monitors"] = monitors
-        return result if result else None
+        return SimulationResults.from_run(
+            self,
+            fields=fields_result,
+            monitors=self.monitors,
+        )
 
     def run_compiled_until_decay(
         self,

--- a/beamz/simulation/core.py
+++ b/beamz/simulation/core.py
@@ -142,7 +142,6 @@ class Simulation:
     def __init__(
         self,
         design: Design = None,
-        devices: list = None,
         sources: list = None,
         monitors: list[Monitor] = None,
         boundaries: list[Boundary] = None,
@@ -152,7 +151,6 @@ class Simulation:
         plane_2d: str = "xy",
     ):
         self.design = design
-        devices = devices or []
         sources = sources or []
         monitors = monitors or []
         boundaries = boundaries or []
@@ -161,9 +159,8 @@ class Simulation:
         self.plane_2d = plane_2d.lower()
         if self.plane_2d not in ["xy", "yz", "xz"]:
             self.plane_2d = "xy"
-        self.sources, self.monitors, self.devices = self._normalize_devices(
+        self.sources, self.monitors = self._normalize_specs(
             design=design,
-            devices=devices,
             sources=sources,
             monitors=monitors,
         )
@@ -248,23 +245,12 @@ class Simulation:
         return ordered
 
     @classmethod
-    def _normalize_devices(cls, *, design, devices, sources, monitors):
+    def _normalize_specs(cls, *, design, sources, monitors):
         normalized_sources = list(sources)
         normalized_monitors = list(monitors)
-        other_devices = []
-
-        for device in devices:
-            if isinstance(device, Monitor):
-                normalized_monitors.append(device)
-            else:
-                if hasattr(device, "inject") or hasattr(device, "inject_h"):
-                    normalized_sources.append(device)
-                else:
-                    other_devices.append(device)
 
         if (
             design is not None
-            and not devices
             and not sources
             and not monitors
             and (getattr(design, "sources", None) or getattr(design, "monitors", None))
@@ -280,10 +266,7 @@ class Simulation:
 
         normalized_sources = cls._dedupe_devices(normalized_sources)
         normalized_monitors = cls._dedupe_devices(normalized_monitors)
-        normalized_devices = cls._dedupe_devices(
-            [*normalized_sources, *normalized_monitors, *other_devices]
-        )
-        return normalized_sources, normalized_monitors, normalized_devices
+        return normalized_sources, normalized_monitors
 
     def step(self):
         """Perform one FDTD time step with correct Huygens source timing.
@@ -293,10 +276,10 @@ class Simulation:
         if self.current_step >= self.num_steps:
             return False
 
-        # Legacy devices (only have inject(), no inject_h/inject_e): inject before update
+        # Legacy sources (only have inject(), no inject_h/inject_e): inject before update
         self._inject_legacy_sources()
 
-        # Collect source terms from legacy devices (if any)
+        # Collect source terms from source objects that expose packed source terms.
         source_j, source_m = self._collect_source_terms()
 
         # 1. H update
@@ -325,9 +308,7 @@ class Simulation:
 
     def _record_monitors(self):
         """Record data from Monitor devices during simulation."""
-        for device in self.devices:
-            if not isinstance(device, Monitor):
-                continue
+        for device in self.monitors:
             should_record = device.should_record(self.current_step)
             dft_every_step = bool(
                 getattr(device, "dft_enabled", False)
@@ -364,7 +345,7 @@ class Simulation:
 
     def _inject_h_sources(self):
         """Inject magnetic currents (M) into H-fields after H update."""
-        for device in self.devices:
+        for device in self.sources:
             if hasattr(device, "inject_h"):
                 device.inject_h(
                     self.fields,
@@ -377,7 +358,7 @@ class Simulation:
 
     def _inject_e_sources(self):
         """Inject electric currents (J) into E-fields after E update."""
-        for device in self.devices:
+        for device in self.sources:
             if hasattr(device, "inject_e"):
                 device.inject_e(
                     self.fields,
@@ -390,7 +371,7 @@ class Simulation:
 
     def _inject_legacy_sources(self):
         """Inject from devices that only have inject() (no inject_h/inject_e)."""
-        for device in self.devices:
+        for device in self.sources:
             if hasattr(device, "inject") and not hasattr(device, "inject_h"):
                 device.inject(
                     self.fields,
@@ -406,7 +387,7 @@ class Simulation:
         source_j = {}  # Electric currents for E-field update
         source_m = {}  # Magnetic currents for H-field update
 
-        for device in self.devices:
+        for device in self.sources:
             if hasattr(device, "get_source_terms"):
                 j, m = device.get_source_terms(
                     self.fields,
@@ -659,7 +640,8 @@ class Simulation:
         )
         program = compile_simulation(
             design=self.design,
-            devices=self.devices,
+            sources=self.sources,
+            monitors=self.monitors,
             boundaries=self.boundaries,
             run_cfg=run_cfg,
         )
@@ -1072,8 +1054,8 @@ class Simulation:
     def _named_monitors(self):
         return {
             device.name: device
-            for device in self.devices
-            if isinstance(device, Monitor) and getattr(device, "name", None)
+            for device in self.monitors
+            if getattr(device, "name", None)
         }
 
     def _sample_monitor_component_spectrum(

--- a/beamz/visual/animation.py
+++ b/beamz/visual/animation.py
@@ -413,8 +413,19 @@ class JupyterAnimator:
                     "extent": extent,
                     "design": design,
                     "boundaries": boundaries,
+                    "sources": sources,
+                    "monitors": monitors,
                     "plane_2d": plane_2d,
                 }
+            else:
+                if sources is not None:
+                    self.metadata["sources"] = sources
+                if monitors is not None:
+                    self.metadata["monitors"] = monitors
+                if boundaries is not None:
+                    self.metadata["boundaries"] = boundaries
+                if design is not None:
+                    self.metadata["design"] = design
 
         # Track global max for auto-scaling
         if self.axis_scale is None:
@@ -574,6 +585,15 @@ class JupyterAnimator:
                     alpha=self.line_opacity,
                 )
 
+    def _overlay_metadata(self):
+        """Return stored overlay metadata for replayed frames."""
+        return (
+            self.metadata.get("design"),
+            self.metadata.get("boundaries"),
+            self.metadata.get("sources"),
+            self.metadata.get("monitors"),
+        )
+
     def _build_replay(self, fps, facecolor="none"):
         """Build a FuncAnimation from stored frames.
 
@@ -637,16 +657,11 @@ class JupyterAnimator:
             title = ax.set_title("")
             plt.tight_layout()
 
-        self._add_overlays(
-            ax,
-            self.metadata.get("design"),
-            self.metadata.get("boundaries"),
-        )
+        design, boundaries, sources, monitors = self._overlay_metadata()
+        self._add_overlays(ax, design, boundaries, sources, monitors)
 
         if self.clean_visualization:
-            draw_scale_bar(
-                ax, self.metadata.get("design"), wavelength=self.wavelength, fontsize=14
-            )
+            draw_scale_bar(ax, design, wavelength=self.wavelength, fontsize=14)
 
         def update(frame_idx):
             im.set_data(self.frames[frame_idx])
@@ -804,11 +819,8 @@ class JupyterAnimator:
                         )
                     plt.tight_layout()
 
-                self._add_overlays(
-                    ax,
-                    self.metadata.get("design"),
-                    self.metadata.get("boundaries"),
-                )
+                design, boundaries, sources, monitors = self._overlay_metadata()
+                self._add_overlays(ax, design, boundaries, sources, monitors)
 
                 plt.show()
 

--- a/beamz/visual/animation.py
+++ b/beamz/visual/animation.py
@@ -93,6 +93,8 @@ def animate_manual_field(
     smoothing=0.25,
     design=None,
     boundaries=None,
+    sources=None,
+    monitors=None,
     show_structures=True,
     show_sources=True,
     show_monitors=True,
@@ -117,8 +119,10 @@ def animate_manual_field(
         pause: Seconds to pause after drawing (keeps UI responsive).
         auto_interval: Recompute auto scaling every N frames when ``axis_scale`` is ``None``.
         smoothing: Exponential smoothing factor (0-1) applied to auto scale updates.
-        design: Optional FDTD design object to overlay structures, sources, and monitors.
+        design: Optional FDTD design object to overlay structures.
         boundaries: Optional list of boundary objects (PML, ABC, etc.) to visualize.
+        sources: Optional explicit source list for overlays.
+        monitors: Optional explicit monitor list for overlays.
         show_structures: Boolean to control if design structures are overlaid.
         show_sources: Boolean to control if design sources are overlaid.
         show_monitors: Boolean to control if design monitors are overlaid.
@@ -230,7 +234,8 @@ def animate_manual_field(
                 design,
                 line_color=line_color,
                 line_opacity=line_opacity,
-                sources=getattr(design, "sources", []) if show_sources else [],
+                sources=sources if show_sources else [],
+                monitors=monitors if show_monitors else [],
                 show_monitors=show_monitors,
             )
 
@@ -371,6 +376,8 @@ class JupyterAnimator:
         extent=None,
         design=None,
         boundaries=None,
+        sources=None,
+        monitors=None,
         plane_2d="xy",
     ):
         """Add a frame and optionally display it live.
@@ -385,6 +392,8 @@ class JupyterAnimator:
             extent: Matplotlib extent tuple (xmin, xmax, ymin, ymax)
             design: Design object for structure overlays
             boundaries: List of boundary objects for overlays
+            sources: Explicit source list for overlays
+            monitors: Explicit monitor list for overlays
             plane_2d: Simulation plane ('xy', 'yz', 'xz')
         """
         import time
@@ -431,6 +440,8 @@ class JupyterAnimator:
                     extent,
                     design,
                     boundaries,
+                    sources,
+                    monitors,
                     plane_2d,
                 )
                 self._last_display_time = current_time
@@ -446,6 +457,8 @@ class JupyterAnimator:
         extent,
         design,
         boundaries,
+        sources,
+        monitors,
         plane_2d,
     ):
         """Display a single frame in Jupyter, reusing a persistent figure."""
@@ -501,7 +514,7 @@ class JupyterAnimator:
                 plt.tight_layout()
 
             # Add structure overlays (static, only done once)
-            self._add_overlays(self._ax, design, boundaries)
+            self._add_overlays(self._ax, design, boundaries, sources, monitors)
 
             # Add scale bar for clean visualization
             if self.clean_visualization:
@@ -538,13 +551,15 @@ class JupyterAnimator:
             self._cbar = None
             self._title = None
 
-    def _add_overlays(self, ax, design, boundaries):
+    def _add_overlays(self, ax, design, boundaries, sources, monitors):
         """Add structure, source, monitor, and boundary overlays."""
         add_design_overlays(
             ax,
             design,
             line_color=self.line_color,
             line_opacity=self.line_opacity,
+            sources=sources,
+            monitors=monitors,
             skip_background=True,
         )
 

--- a/beamz/visual/design_3d.py
+++ b/beamz/visual/design_3d.py
@@ -6,7 +6,13 @@ from beamz.visual.helpers import display_status, get_si_scale_and_label
 from beamz.visual.overlays import _get_deterministic_color
 
 
-def show_design_3d(design, unify_structures=True, max_vertices_for_unification=50):
+def show_design_3d(
+    design,
+    unify_structures=True,
+    max_vertices_for_unification=50,
+    sources=None,
+    monitors=None,
+):
     """Display the design using 3D plotly visualization."""
     try:
         import plotly.graph_objects as go
@@ -55,11 +61,11 @@ def show_design_3d(design, unify_structures=True, max_vertices_for_unification=5
     color_index = 0
 
     # Add monitors
-    for idx, monitor in enumerate(design.monitors):
+    for idx, monitor in enumerate(monitors or []):
         _add_monitor_to_3d_plot(fig, monitor, scale, unit, design=design, index=idx)
 
     # Add sources
-    for idx, source in enumerate(design.sources):
+    for idx, source in enumerate(sources or []):
         if isinstance(source, ModeSource):
             _add_mode_source_to_3d_plot(
                 fig, source, scale, unit, design=design, index=idx

--- a/beamz/visual/design_viz.py
+++ b/beamz/visual/design_viz.py
@@ -88,17 +88,19 @@ def determine_if_3d(design):
     return False
 
 
-def show_design(design, unify_structures=True):
+def show_design(design, unify_structures=True, sources=None, monitors=None):
     """Display the design visually using 2D matplotlib or 3D plotly."""
     if determine_if_3d(design):
         from beamz.visual.design_3d import show_design_3d
 
-        show_design_3d(design, unify_structures)
+        show_design_3d(
+            design, unify_structures, sources=sources, monitors=monitors
+        )
     else:
-        show_design_2d(design, unify_structures)
+        show_design_2d(design, unify_structures, sources=sources, monitors=monitors)
 
 
-def show_design_2d(design, unify_structures=True):
+def show_design_2d(design, unify_structures=True, sources=None, monitors=None):
     """Display the design using 2D matplotlib visualization."""
     import matplotlib.pyplot as plt
 
@@ -115,12 +117,8 @@ def show_design_2d(design, unify_structures=True):
         tmp_design = design.copy()
         tmp_design.unify_polygons()
         structures_to_plot = tmp_design.structures
-        sources_to_plot = tmp_design.sources
-        monitors_to_plot = tmp_design.monitors
     else:
         structures_to_plot = design.structures
-        sources_to_plot = design.sources
-        monitors_to_plot = design.monitors
 
     fig, ax = plt.subplots(figsize=figsize)
     ax.set_aspect("equal")
@@ -151,12 +149,12 @@ def show_design_2d(design, unify_structures=True):
             structure.add_to_plot(ax, facecolor=material_colors[material_key])
 
     # Add sources
-    for source in sources_to_plot:
+    for source in (sources or []):
         if hasattr(source, "add_to_plot"):
             source.add_to_plot(ax)
 
     # Add monitors
-    for monitor in monitors_to_plot:
+    for monitor in (monitors or []):
         if hasattr(monitor, "add_to_plot"):
             monitor.add_to_plot(ax)
 

--- a/beamz/visual/overlays.py
+++ b/beamz/visual/overlays.py
@@ -28,6 +28,7 @@ def add_design_overlays(
     line_color="gray",
     line_opacity=0.5,
     sources=None,
+    monitors=None,
     show_monitors=True,
     skip_background=False,
 ):
@@ -35,10 +36,11 @@ def add_design_overlays(
 
     Args:
         ax: Matplotlib axes.
-        design: Design object whose structures/sources/monitors to overlay.
+        design: Design object whose structures to overlay.
         line_color: Edge colour for structures and monitors.
         line_opacity: Alpha for structure and monitor outlines.
-        sources: If given, overlay these; otherwise use ``design.sources``.
+        sources: Optional explicit source list to overlay.
+        monitors: Optional explicit monitor list to overlay.
         show_monitors: Whether to draw monitors.
         skip_background: If True, skip the first structure that spans the full design.
     """
@@ -82,14 +84,12 @@ def add_design_overlays(
                 alpha=line_opacity,
             )
 
-    for source in (
-        sources if sources is not None else getattr(design, "sources", []) or []
-    ):
+    for source in (sources or []):
         if hasattr(source, "add_to_plot"):
             source.add_to_plot(ax)
 
     if show_monitors:
-        for monitor in getattr(design, "monitors", []) or []:
+        for monitor in (monitors or []):
             if hasattr(monitor, "add_to_plot"):
                 monitor.add_to_plot(ax, edgecolor=line_color, alpha=line_opacity)
 

--- a/beamz/visual/runner.py
+++ b/beamz/visual/runner.py
@@ -249,12 +249,18 @@ def _update_live_display(
 
 def _collect_results(sim, field_history, cfg, jupyter_animator):
     """Collect and return simulation results."""
-    monitors = [device for device in sim.devices if hasattr(device, "power_history")]
-    result = {}
-    if cfg.save_fields:
-        result["fields"] = field_history
-    if monitors:
-        result["monitors"] = monitors
-    if jupyter_animator and jupyter_animator.frames:
-        result["animation"] = jupyter_animator
-    return result if result else None
+    from beamz.simulation.core import SimulationResults
+
+    monitors = [device for device in sim.monitors if hasattr(device, "power_history")]
+    fields = field_history if cfg.save_fields else None
+    animation = (
+        jupyter_animator
+        if jupyter_animator is not None and jupyter_animator.frames
+        else None
+    )
+    return SimulationResults.from_run(
+        sim,
+        fields=fields,
+        monitors=monitors,
+        animation=animation,
+    )

--- a/beamz/visual/runner.py
+++ b/beamz/visual/runner.py
@@ -83,13 +83,9 @@ def run_with_visualization(sim, **kwargs):
 
 def _setup_visualization(sim, cfg):
     """Set up all visualization components."""
-    from beamz.devices.monitors.monitors import Monitor
-
     active_monitor = None
     if cfg.animate_live and sim.is_3d:
-        active_monitor = next(
-            (d for d in sim.devices if isinstance(d, Monitor) and d.is_3d), None
-        )
+        active_monitor = next((d for d in sim.monitors if d.is_3d), None)
         if not active_monitor:
             cfg.animate_live = None
 
@@ -99,7 +95,7 @@ def _setup_visualization(sim, cfg):
             cfg.animate_live = None
 
     if cfg.wavelength is None:
-        for device in sim.devices:
+        for device in sim.sources:
             if hasattr(device, "wavelength"):
                 cfg.wavelength = device.wavelength
                 break

--- a/beamz/visual/runner.py
+++ b/beamz/visual/runner.py
@@ -175,6 +175,8 @@ def _record_video_frame(sim, video_recorder, cfg):
         extent=(0, sim.design.width, 0, sim.design.height),
         design=sim.design,
         boundaries=sim.boundaries,
+        sources=sim.sources,
+        monitors=sim.monitors,
         plane_2d=sim.plane_2d,
     )
 
@@ -218,6 +220,8 @@ def _update_live_display(
             extent=extent,
             design=sim.design,
             boundaries=sim.boundaries,
+            sources=sim.sources,
+            monitors=sim.monitors,
             plane_2d=sim.plane_2d,
         )
     else:
@@ -230,6 +234,8 @@ def _update_live_display(
             units=units,
             design=sim.design,
             boundaries=sim.boundaries,
+            sources=sim.sources,
+            monitors=sim.monitors,
             pause=0.001,
             axis_scale=cfg.axis_scale,
             cmap=cfg.cmap,

--- a/beamz/visual/scene/_beamz.py
+++ b/beamz/visual/scene/_beamz.py
@@ -122,7 +122,8 @@ def simulation_to_scene(simulation: Any) -> SceneSpec:
             "plane_2d": getattr(simulation, "plane_2d", "xy"),
             "dt": getattr(simulation, "dt", None),
             "num_steps": getattr(simulation, "num_steps", None),
-            "num_devices": len(getattr(simulation, "devices", [])),
+            "num_devices": len(_simulation_sources(simulation))
+            + len(_simulation_monitors(simulation)),
             "num_boundaries": len(getattr(simulation, "boundaries", [])),
         },
     )
@@ -635,13 +636,17 @@ def _simulation_sources(simulation: Any) -> list[Any]:
 def _combined_simulation_items(
     simulation: Any, *, attr_name: str, predicate: Callable[[Any], bool]
 ) -> list[Any]:
-    items = list(getattr(getattr(simulation, "design", None), attr_name, []))
+    items = [
+        item
+        for item in list(getattr(getattr(simulation, "design", None), attr_name, []))
+        if predicate(item)
+    ]
     seen = {id(item) for item in items}
-    for device in getattr(simulation, "devices", []):
-        if not predicate(device) or id(device) in seen:
+    for item in getattr(simulation, attr_name, []):
+        if not predicate(item) or id(item) in seen:
             continue
-        seen.add(id(device))
-        items.append(device)
+        seen.add(id(item))
+        items.append(item)
     return items
 
 

--- a/beamz/visual/scene/_beamz.py
+++ b/beamz/visual/scene/_beamz.py
@@ -57,7 +57,7 @@ class _Bounds:
 def looks_like_beamz_design(value: Any) -> bool:
     return all(
         hasattr(value, name)
-        for name in ("structures", "sources", "monitors", "width", "height")
+        for name in ("structures", "width", "height")
     )
 
 
@@ -78,8 +78,6 @@ def design_to_scene(design: Any) -> SceneSpec:
     objects = [
         _domain_box(design, bounds),
         *_structure_objects(design),
-        *_monitor_objects(getattr(design, "monitors", [])),
-        *_source_objects(getattr(design, "sources", [])),
     ]
     return _build_scene(
         title="BEAMZ Design",
@@ -89,8 +87,6 @@ def design_to_scene(design: Any) -> SceneSpec:
             "object_type": type(design).__name__,
             "is_3d": bool(getattr(design, "is_3d", False)),
             "num_structures": len(getattr(design, "structures", [])),
-            "num_sources": len(getattr(design, "sources", [])),
-            "num_monitors": len(getattr(design, "monitors", [])),
         },
     )
 
@@ -636,11 +632,7 @@ def _simulation_sources(simulation: Any) -> list[Any]:
 def _combined_simulation_items(
     simulation: Any, *, attr_name: str, predicate: Callable[[Any], bool]
 ) -> list[Any]:
-    items = [
-        item
-        for item in list(getattr(getattr(simulation, "design", None), attr_name, []))
-        if predicate(item)
-    ]
+    items = []
     seen = {id(item) for item in items}
     for item in getattr(simulation, attr_name, []):
         if not predicate(item) or id(item) in seen:

--- a/beamz/visual/video.py
+++ b/beamz/visual/video.py
@@ -86,6 +86,8 @@ class VideoRecorder:
         extent=None,
         design=None,
         boundaries=None,
+        sources=None,
+        monitors=None,
         plane_2d="xy",
     ):
         """Add a frame to the video recording.
@@ -100,6 +102,8 @@ class VideoRecorder:
             extent: Matplotlib extent tuple (xmin, xmax, ymin, ymax)
             design: Design object for structure overlay
             boundaries: List of boundary objects (PML, etc.)
+            sources: Explicit source list for overlays
+            monitors: Explicit monitor list for overlays
             plane_2d: Simulation plane ('xy', 'yz', 'xz')
         """
         import numpy as np
@@ -111,6 +115,8 @@ class VideoRecorder:
             self.extent = extent
             self.design = design
             self.boundaries = boundaries
+            self.sources = sources
+            self.monitors = monitors
             self.plane_2d = plane_2d
 
         # Store frame data (make a copy to avoid reference issues)
@@ -263,6 +269,8 @@ class VideoRecorder:
                         self.design,
                         line_color=self.line_color,
                         line_opacity=self.line_opacity,
+                        sources=self.sources,
+                        monitors=self.monitors,
                     )
 
                     # Draw PML boundaries

--- a/examples/2D_basics/0_dipole.py
+++ b/examples/2D_basics/0_dipole.py
@@ -15,5 +15,5 @@ signal = ramped_cosine(time_steps, amplitude=1.0, frequency=LIGHT_SPEED/WL, ramp
 source = GaussianSource(position=(4*µm, 5*µm), width=WL/6, signal=signal)
 
 # Add source and PML boundaries to the simulation.
-sim = Simulation(design=design, devices=[source], boundaries=[PML(edges='all', thickness=2*WL)], time=time_steps, resolution=DX)
+sim = Simulation(design=design, sources=[source], boundaries=[PML(edges='all', thickness=2*WL)], time=time_steps, resolution=DX)
 sim.run(animate_live="Ez", animation_interval=1, clean_visualization=True)

--- a/examples/2D_basics/1_mmi.py
+++ b/examples/2D_basics/1_mmi.py
@@ -103,7 +103,7 @@ source = ModeSource(
 # Run the simulation
 sim = Simulation(
     design=design,
-    devices=[source],
+    sources=[source],
     boundaries=[PML(edges="all", thickness=1.2 * WL)],
     time=time_steps,
     resolution=DX,

--- a/examples/2D_basics/2_resring.py
+++ b/examples/2D_basics/2_resring.py
@@ -38,7 +38,7 @@ source = ModeSource(
 # Run the simulation
 sim = Simulation(
     design=design,
-    devices=[source],
+    sources=[source],
     boundaries=[PML(edges='all', thickness=1.2*WL)],
     time=time_steps,
     resolution=DX

--- a/examples/2D_basics/3_waveguide.py
+++ b/examples/2D_basics/3_waveguide.py
@@ -41,7 +41,7 @@ source = ModeSource(
 # Run the simulation
 sim = Simulation(
     design=design, 
-    devices=[source], 
+    sources=[source], 
     boundaries=[PML(edges='all', thickness=1.2*WL)],
     time=time_steps,
     resolution=DX

--- a/examples/3D_basics/0_mmi_3d.py
+++ b/examples/3D_basics/0_mmi_3d.py
@@ -420,7 +420,7 @@ flux_monitor = Monitor(
 
 sim = Simulation(
     design=design,
-    devices=[source, flux_monitor],
+    sources=[source], monitors=[flux_monitor],
     boundaries=[PML(edges=PML_EDGES, thickness=PML_THICKNESS)],
     time=time_steps,
     resolution=DX,
@@ -449,7 +449,7 @@ mid_source = ModeSource(
 )
 sim_mid = Simulation(
     design=design,
-    devices=[mid_source],
+    sources=[mid_source],
     boundaries=[PML(edges=PML_EDGES, thickness=PML_THICKNESS)],
     time=time_steps,
     resolution=DX,
@@ -498,7 +498,7 @@ xy_flux_source = ModeSource(
 )
 sim_xy_flux = Simulation(
     design=design,
-    devices=[xy_flux_source],
+    sources=[xy_flux_source],
     boundaries=[PML(edges=PML_EDGES, thickness=PML_THICKNESS)],
     time=time_steps,
     resolution=DX,

--- a/examples/3D_basics/1_3d_sim.py
+++ b/examples/3D_basics/1_3d_sim.py
@@ -28,7 +28,7 @@ signal = ramped_cosine(time_steps, amplitude=1.0, frequency=LIGHT_SPEED/WL, ramp
 source = GaussianSource(position=(2.5*µm, 3*µm, 1.2*µm), width=WL/6, signal=signal)
 
 # Add source, monitor, and PML boundaries to the simulation.
-sim = Simulation(design=design, devices=[source, monitor], boundaries=[PML(edges='all', thickness=1.0*WL)], time=time_steps, resolution=DX)
+sim = Simulation(design=design, sources=[source], monitors=[monitor], boundaries=[PML(edges='all', thickness=1.0*WL)], time=time_steps, resolution=DX)
 
 sim.show()
 

--- a/examples/3D_basics/2_3d_waveguide.py
+++ b/examples/3D_basics/2_3d_waveguide.py
@@ -75,7 +75,7 @@ monitor_xy = Monitor(
 # 5. Run the Simulation
 sim = Simulation(
     design=design, 
-    devices=[source, monitor_xy], 
+    sources=[source], monitors=[monitor_xy], 
     boundaries=[PML(edges='all', thickness=0.75*WL)],
     time=time_steps,
     resolution=DX)

--- a/examples/benchmarks/0_basic_meep_cpu_comp/plot_results.py
+++ b/examples/benchmarks/0_basic_meep_cpu_comp/plot_results.py
@@ -236,7 +236,11 @@ def main() -> int:
         results_dirs = [path.resolve() for path in args.results_dir]
         results_dir = results_dirs[0]
     else:
-        results_dir = _latest_results_dir()
+        try:
+            results_dir = _latest_results_dir()
+        except FileNotFoundError as exc:
+            print(f"{exc} Run sim_coupler_compare.py first to generate benchmark data.")
+            return 0
         results_dirs = [results_dir]
     rows = _load_summary_rows(
         results_dirs,

--- a/examples/benchmarks/0_basic_meep_cpu_comp/sim_coupler_compare.py
+++ b/examples/benchmarks/0_basic_meep_cpu_comp/sim_coupler_compare.py
@@ -331,7 +331,7 @@ def run_beamz_single(
 
     sim = Simulation(
         design=design,
-        devices=[source],
+        sources=[source],
         boundaries=[PML(edges="all", thickness=cfg.pml_um * 1e-6)],
         time=t,
         resolution=dx_m,

--- a/examples/compact_models/tiny_beamz_crossing.py
+++ b/examples/compact_models/tiny_beamz_crossing.py
@@ -450,7 +450,8 @@ for path in mode_plot_paths:
 # simulation object.
 sim = Simulation(
     design=design,
-    devices=[source, m_fwd, *out_monitors],
+    sources=[source],
+    monitors=[m_fwd, *out_monitors],
     boundaries=[
         PML(edges=["left", "right", "top", "bottom"], thickness=PML_XY), 
         PML(edges=["front", "back"], thickness=PML_Z)],

--- a/examples/compact_models/tiny_beamz_crossing.py
+++ b/examples/compact_models/tiny_beamz_crossing.py
@@ -301,19 +301,26 @@ def save_mode_profile_plot(
 # 1. Import the GDSFactory/PDK component, extrude it to 3D, pad the domain,
 # and extend the ports into uniform straight sections.
 OUT_DIR.mkdir(parents=True, exist_ok=True)
-prepared = gdsf.prepare_component(
-    COMPONENT_NAME,
-    layer=LAYER,
-    n_core=N_CORE,
-    n_clad=N_CLAD,
-    core_thickness=CORE_T,
-    clad_below=CLAD_BELOW,
-    clad_above=CLAD_ABOVE,
-    xy_padding=EXTENSION,
-    z_padding=Z_PADDING,
-    extension=EXTENSION,
-    port_overlap=PORT_OVERLAP,
-)
+try:
+    prepared = gdsf.prepare_component(
+        COMPONENT_NAME,
+        layer=LAYER,
+        n_core=N_CORE,
+        n_clad=N_CLAD,
+        core_thickness=CORE_T,
+        clad_below=CLAD_BELOW,
+        clad_above=CLAD_ABOVE,
+        xy_padding=EXTENSION,
+        z_padding=Z_PADDING,
+        extension=EXTENSION,
+        port_overlap=PORT_OVERLAP,
+    )
+except ValueError as exc:
+    print(
+        f"{exc} Install or activate the matching gdsfactory PDK before running "
+        f"{Path(__file__).name}."
+    )
+    raise SystemExit(0) from exc
 component_label, design, ports = prepared["component_label"], prepared["design"], prepared["ports"]
 source_port, output_ports = "o1", ["o2", "o3", "o4"]
 dx, dt = dxdt(WL0, n_max=N_CORE, dims=3, safety_factor=0.999, points_per_wavelength=PPW)

--- a/examples/optimization/0_ceviche_bend.py
+++ b/examples/optimization/0_ceviche_bend.py
@@ -79,8 +79,14 @@ for step in range(STEPS):
                                  accumulate_power=True, record_fields=False)
     
     # Run forward simulation with output monitor
-    sim_fwd = Simulation(grid, [src_fwd, monitor_input_flux, output_monitor_fwd], 
-                        [PML(edges='all', thickness=1*µm)], time=time, resolution=DX)
+    sim_fwd = Simulation(
+        design=grid,
+        sources=[src_fwd],
+        monitors=[monitor_input_flux, output_monitor_fwd],
+        boundaries=[PML(edges="all", thickness=1 * µm)],
+        time=time,
+        resolution=DX,
+    )
     
     print(f"[{step+1}/{STEPS}] Forward Sim...", end="\r")
     results = sim_fwd.run(save_fields=['Ez'], field_subsample=2)
@@ -110,8 +116,14 @@ for step in range(STEPS):
     backward_monitor = Monitor(design=grid, start=(1.5*µm, H/2-WG_W*2), end=(1.5*µm, H/2+WG_W*2),
                               accumulate_power=True, record_fields=False)
     
-    sim_adj = Simulation(grid, [src_adj, monitor_back_flux, backward_monitor], 
-                        [PML(edges='all', thickness=1*µm)], time=time, resolution=DX)
+    sim_adj = Simulation(
+        design=grid,
+        sources=[src_adj],
+        monitors=[monitor_back_flux, backward_monitor],
+        boundaries=[PML(edges="all", thickness=1 * µm)],
+        time=time,
+        resolution=DX,
+    )
     
     adj_results = sim_adj.run(save_fields=['Ez'], field_subsample=2)
     adj_ez_history = [np.array(field) for field in adj_results['fields']['Ez']] if adj_results and 'fields' in adj_results else []
@@ -215,8 +227,14 @@ for i, wl_val in enumerate(wavelengths):
     mon_out = Monitor(design=grid, start=(W/2-WG_W*2, 1.5*µm), end=(W/2+WG_W*2, 1.5*µm), accumulate_power=True)
     
     # Simulation
-    sim_sweep = Simulation(grid, [src_sweep, mon_in, mon_out], 
-                           [PML(edges='all', thickness=1*µm)], time=time_sweep, resolution=DX)
+    sim_sweep = Simulation(
+        design=grid,
+        sources=[src_sweep],
+        monitors=[mon_in, mon_out],
+        boundaries=[PML(edges="all", thickness=1 * µm)],
+        time=time_sweep,
+        resolution=DX,
+    )
     
     # Run (no field saving needed for sweep, faster)
     sim_sweep.run(save_fields=[], field_subsample=10)
@@ -251,7 +269,14 @@ src_final.initialize(grid.permittivity, DX)
 mon_in_final = Monitor(design=grid, start=(1.5*µm, H/2-WG_W*2), end=(1.5*µm, H/2+WG_W*2), accumulate_power=True)
 mon_out_final = Monitor(design=grid, start=(W/2-WG_W*2, 1.5*µm), end=(W/2+WG_W*2, 1.5*µm), accumulate_power=True)
 
-sim_final = Simulation(grid, [src_final, mon_in_final, mon_out_final], [PML(edges='all', thickness=1*µm)], time=time_sweep, resolution=DX)
+sim_final = Simulation(
+    design=grid,
+    sources=[src_final],
+    monitors=[mon_in_final, mon_out_final],
+    boundaries=[PML(edges="all", thickness=1 * µm)],
+    time=time_sweep,
+    resolution=DX,
+)
 results_final = sim_final.run(save_fields=['Ez', 'Hx', 'Hy'], field_subsample=1)
 
 # Calculate final transmission for title

--- a/examples/optimization/1_1x2_demux.py
+++ b/examples/optimization/1_1x2_demux.py
@@ -233,9 +233,10 @@ def run_forward(grid, wavelength, wave, fields=("Ez",)):
         )
     ]
     sim = Simulation(
-        grid,
-        [source, *monitors],
-        [PML(edges="all", thickness=PML_T)],
+        design=grid,
+        sources=[source],
+        monitors=monitors,
+        boundaries=[PML(edges="all", thickness=PML_T)],
         time=wave["time"],
         resolution=DX,
     )
@@ -253,9 +254,9 @@ def run_adjoint(grid, wavelength, target_port, wave):
         direction="-x",
     )
     sim = Simulation(
-        grid,
-        [source],
-        [PML(edges="all", thickness=PML_T)],
+        design=grid,
+        sources=[source],
+        boundaries=[PML(edges="all", thickness=PML_T)],
         time=wave["time"],
         resolution=DX,
     )

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+from beamz.visual.animation import JupyterAnimator
+
+
+def test_animator_update_persists_overlay_metadata():
+    animator = JupyterAnimator(store_frames=True, live_display=False)
+    sources = [object()]
+    monitors = [object()]
+    boundaries = [object()]
+    design = object()
+
+    animator.update(
+        np.ones((2, 2)),
+        t=0.0,
+        step=0,
+        num_steps=1,
+        design=design,
+        boundaries=boundaries,
+        sources=sources,
+        monitors=monitors,
+    )
+
+    assert animator.metadata["design"] is design
+    assert animator.metadata["boundaries"] is boundaries
+    assert animator.metadata["sources"] is sources
+    assert animator.metadata["monitors"] is monitors
+
+
+def test_animator_replay_uses_stored_overlay_metadata(monkeypatch):
+    animator = JupyterAnimator(store_frames=True, live_display=False)
+    sources = [object()]
+    monitors = [object()]
+    boundaries = [object()]
+    design = object()
+
+    animator.update(
+        np.ones((2, 2)),
+        t=0.0,
+        step=0,
+        num_steps=1,
+        design=design,
+        boundaries=boundaries,
+        sources=sources,
+        monitors=monitors,
+    )
+
+    seen = {}
+
+    def capture(ax, design_arg, boundaries_arg, sources_arg, monitors_arg):
+        seen["design"] = design_arg
+        seen["boundaries"] = boundaries_arg
+        seen["sources"] = sources_arg
+        seen["monitors"] = monitors_arg
+
+    monkeypatch.setattr(animator, "_add_overlays", capture)
+    fig, anim = animator._build_replay(fps=30)
+
+    assert fig is not None
+    assert anim is not None
+    assert seen == {
+        "design": design,
+        "boundaries": boundaries,
+        "sources": sources,
+        "monitors": monitors,
+    }

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -72,7 +72,7 @@ class TestDipoleRadiation:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.2 * wavelength)],
             time=time,
             resolution=dx,
@@ -144,7 +144,7 @@ class TestDipoleRadiation:
 
             sim = Simulation(
                 design=design,
-                devices=[source],
+                sources=[source],
                 boundaries=[PML(thickness=1.2 * wavelength)],
                 time=time,
                 resolution=dx,
@@ -212,7 +212,7 @@ class TestCavityResonance:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -296,7 +296,7 @@ class TestGridConvergence:
 
             sim = Simulation(
                 design=design,
-                devices=[source],
+                sources=[source],
                 boundaries=[PML(thickness=wavelength)],
                 time=time,
                 resolution=dx,
@@ -355,7 +355,7 @@ class TestGridConvergence:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -442,7 +442,7 @@ class TestWaveguideGroupVelocity:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.2 * wavelength)],
             time=time,
             resolution=dx,

--- a/tests/test_compiled_engine.py
+++ b/tests/test_compiled_engine.py
@@ -59,14 +59,14 @@ def test_run_compiled_matches_python_step_path(small_sim_params):
 
     sim_python = Simulation(
         design=design.copy(),
-        devices=[source_a],
+        sources=[source_a],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
     )
     sim_compiled = Simulation(
         design=design.copy(),
-        devices=[source_b],
+        sources=[source_b],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
@@ -98,7 +98,7 @@ def test_compiled_monitor_power_is_populated(small_sim_params):
 
     sim = Simulation(
         design=design,
-        devices=[source, monitor],
+        sources=[source], monitors=[monitor],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
@@ -125,7 +125,7 @@ def test_compiled_monitor_accumulates_across_chunks(small_sim_params):
     )
     sim_full = Simulation(
         design=design.copy(),
-        devices=[source_a, monitor_a],
+        sources=[source_a], monitors=[monitor_a],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
@@ -141,7 +141,7 @@ def test_compiled_monitor_accumulates_across_chunks(small_sim_params):
     )
     sim_chunked = Simulation(
         design=design.copy(),
-        devices=[source_b, monitor_b],
+        sources=[source_b], monitors=[monitor_b],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
@@ -185,7 +185,7 @@ def test_compiled_frequency_monitor_matches_direct_sum(small_sim_params):
 
     sim = Simulation(
         design=design,
-        devices=[source, monitor],
+        sources=[source], monitors=[monitor],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
@@ -223,7 +223,7 @@ def test_compiled_frequency_monitor_accumulates_across_chunks(small_sim_params):
     )
     sim_full = Simulation(
         design=design.copy(),
-        devices=[source_a, monitor_a],
+        sources=[source_a], monitors=[monitor_a],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
@@ -241,7 +241,7 @@ def test_compiled_frequency_monitor_accumulates_across_chunks(small_sim_params):
     )
     sim_chunked = Simulation(
         design=design.copy(),
-        devices=[source_b, monitor_b],
+        sources=[source_b], monitors=[monitor_b],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
@@ -303,7 +303,7 @@ def test_compiled_frequency_monitor_3d_populated():
     )
     sim = Simulation(
         design=design,
-        devices=[source, monitor],
+        sources=[source], monitors=[monitor],
         boundaries=[PML(thickness=0.6 * wl, edges="all")],
         time=t,
         resolution=dx,
@@ -339,7 +339,7 @@ def test_compiled_dft_component_monitor_populated(small_sim_params):
     )
     sim = Simulation(
         design=design,
-        devices=[source, monitor],
+        sources=[source], monitors=[monitor],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
@@ -457,7 +457,7 @@ def test_compiled_program_compiles_once(small_sim_params):
 
     sim = Simulation(
         design=design,
-        devices=[],
+        sources=[], monitors=[],
         boundaries=[PML(thickness=1.0 * wl)],
         time=t,
         resolution=dx,
@@ -528,7 +528,7 @@ def test_compiled_jaxpr_has_no_host_callbacks(small_sim_params):
 
     sim = Simulation(
         design=design,
-        devices=[source],
+        sources=[source],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
@@ -609,7 +609,7 @@ def test_compile_mode_source_builds_e_and_h_specs():
 
     sim = Simulation(
         design=design,
-        devices=[source],
+        sources=[source],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
@@ -633,7 +633,7 @@ def test_cache_reuse_across_equal_chunks(small_sim_params):
 
     sim = Simulation(
         design=design,
-        devices=[source],
+        sources=[source],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
@@ -662,14 +662,14 @@ def test_waveform_absolute_indexing_correctness(small_sim_params):
 
     sim_single = Simulation(
         design=design.copy(),
-        devices=[source_a],
+        sources=[source_a],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,
     )
     sim_chunked = Simulation(
         design=design.copy(),
-        devices=[source_b],
+        sources=[source_b],
         boundaries=[PML(thickness=1.2 * wl)],
         time=t,
         resolution=dx,

--- a/tests/test_gdsf_sax_api.py
+++ b/tests/test_gdsf_sax_api.py
@@ -98,7 +98,8 @@ def test_extract_port_waves_modal_coefficients_synthetic(monkeypatch):
     sim.is_3d = False
     sim.plane_2d = "xy"
     sim.resolution = 1.0
-    sim.devices = [
+    sim.sources = []
+    sim.monitors = [
         Monitor(start=(0.0, 0.0), end=(0.0, 1.0), name="m_src"),
         Monitor(start=(0.0, 0.0), end=(0.0, 1.0), name="m_ref"),
         Monitor(start=(1.0, 0.0), end=(1.0, 1.0), name="m_out"),
@@ -127,7 +128,8 @@ def test_extract_port_waves_modal_coefficients_synthetic(monkeypatch):
 
 def test_get_S_matrix_modal_column_keys_and_shapes(monkeypatch):
     sim = Simulation.__new__(Simulation)
-    sim.devices = []
+    sim.sources = []
+    sim.monitors = []
     sim.is_3d = False
     sim.plane_2d = "xy"
 
@@ -244,7 +246,8 @@ def test_extract_port_waves_cw_modal_coefficients_synthetic(monkeypatch):
     sim.is_3d = False
     sim.plane_2d = "xy"
     sim.resolution = 1.0
-    sim.devices = [
+    sim.sources = []
+    sim.monitors = [
         Monitor(start=(0.0, 0.0), end=(0.0, 1.0), name="m_src"),
         Monitor(start=(0.0, 0.0), end=(0.0, 1.0), name="m_ref"),
         Monitor(start=(1.0, 0.0), end=(1.0, 1.0), name="m_out"),
@@ -276,7 +279,8 @@ def test_extract_port_waves_cw_modal_coefficients_synthetic(monkeypatch):
 
 def test_get_S_matrix_modal_cw_shapes_and_keys(monkeypatch):
     sim = Simulation.__new__(Simulation)
-    sim.devices = []
+    sim.sources = []
+    sim.monitors = []
     sim.is_3d = False
     sim.plane_2d = "xy"
     waves = {
@@ -719,7 +723,8 @@ def test_extract_port_waves_dft_modal_coefficients_synthetic(monkeypatch):
     sim.is_3d = False
     sim.plane_2d = "xy"
     sim.resolution = 1.0
-    sim.devices = [
+    sim.sources = []
+    sim.monitors = [
         Monitor(
             start=(0.0, 0.0),
             end=(0.0, 1.0),
@@ -763,7 +768,8 @@ def test_extract_port_waves_dft_modal_coefficients_synthetic(monkeypatch):
 
 def test_get_S_matrix_modal_dft_keys_shapes_and_valid_mask(monkeypatch):
     sim = Simulation.__new__(Simulation)
-    sim.devices = []
+    sim.sources = []
+    sim.monitors = []
     sim.is_3d = False
     sim.plane_2d = "xy"
     freqs = np.array([1.0, 2.0, 3.0], dtype=float)
@@ -820,7 +826,8 @@ def test_get_S_matrix_modal_dft_keys_shapes_and_valid_mask(monkeypatch):
 
 def test_get_S_matrix_modal_dft_respects_wave_selectors(monkeypatch):
     sim = Simulation.__new__(Simulation)
-    sim.devices = []
+    sim.sources = []
+    sim.monitors = []
     sim.is_3d = False
     sim.plane_2d = "xy"
     freqs = np.array([1.0, 2.0], dtype=float)
@@ -882,7 +889,8 @@ def test_get_S_matrix_modal_dft_respects_wave_selectors(monkeypatch):
 
 def test_get_S_matrix_modal_dft_auto_incident_selector_prefers_dominant(monkeypatch):
     sim = Simulation.__new__(Simulation)
-    sim.devices = []
+    sim.sources = []
+    sim.monitors = []
     sim.is_3d = False
     sim.plane_2d = "xy"
     freqs = np.array([1.0, 2.0], dtype=float)

--- a/tests/test_modal_sparams.py
+++ b/tests/test_modal_sparams.py
@@ -5,7 +5,8 @@ from beamz import PortSpec, Simulation
 
 def _run_modal_cw_column(waves, ports, frequency, output_ports):
     sim = Simulation.__new__(Simulation)
-    sim.devices = []
+    sim.sources = []
+    sim.monitors = []
     sim.is_3d = False
     sim.plane_2d = "xy"
 
@@ -36,7 +37,8 @@ def _run_modal_dft_column(
     waves, ports, frequencies, output_ports, min_incident_db=-40.0
 ):
     sim = Simulation.__new__(Simulation)
-    sim.devices = []
+    sim.sources = []
+    sim.monitors = []
     sim.is_3d = False
     sim.plane_2d = "xy"
 

--- a/tests/test_mode_source.py
+++ b/tests/test_mode_source.py
@@ -495,7 +495,7 @@ class TestModeSourcePropagation:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -559,7 +559,7 @@ class TestModeSourcePropagation:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -889,7 +889,7 @@ class TestModeSourcePolarization:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -1073,7 +1073,7 @@ class TestModeSourceDirectionality3D:
         )
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=0.8 * wavelength)],
             time=time,
             resolution=dx,
@@ -1175,7 +1175,7 @@ class TestModeSourceDirectionality3D:
         )
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=0.8 * wavelength)],
             time=time,
             resolution=dx,
@@ -1352,7 +1352,7 @@ class TestModeSourceDirectionality3D:
 
         sim = Simulation(
             design=design,
-            devices=[source, monitor],
+            sources=[source], monitors=[monitor],
             boundaries=[PML(thickness=0.8 * wavelength)],
             time=time,
             resolution=dx,
@@ -1524,7 +1524,7 @@ class TestModeSourceDirectionality3D:
             )
             sim = Simulation(
                 design=design,
-                devices=[source, monitor],
+                sources=[source], monitors=[monitor],
                 boundaries=[PML(thickness=0.8 * wavelength)],
                 time=time,
                 resolution=dx,

--- a/tests/test_physics_energy.py
+++ b/tests/test_physics_energy.py
@@ -62,7 +62,7 @@ class TestEnergyConservation:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -123,7 +123,7 @@ class TestEnergyConservation:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -174,7 +174,7 @@ class TestEnergyConservation:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -237,7 +237,7 @@ class TestEnergyConservation:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -289,7 +289,7 @@ class TestEnergyConservation:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,

--- a/tests/test_physics_fresnel.py
+++ b/tests/test_physics_fresnel.py
@@ -89,7 +89,7 @@ class TestFresnelCoefficients:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -161,7 +161,7 @@ class TestFresnelCoefficients:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -217,7 +217,7 @@ class TestFresnelCoefficients:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,

--- a/tests/test_physics_interfaces.py
+++ b/tests/test_physics_interfaces.py
@@ -68,7 +68,7 @@ class TestFresnelReflection:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -153,7 +153,7 @@ class TestFresnelReflection:
 
             sim = Simulation(
                 design=design,
-                devices=[source, monitor],
+                sources=[source], monitors=[monitor],
                 boundaries=[PML(thickness=wavelength)],
                 time=time,
                 resolution=dx,
@@ -222,7 +222,7 @@ class TestFresnelReflection:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,

--- a/tests/test_physics_materials.py
+++ b/tests/test_physics_materials.py
@@ -73,7 +73,7 @@ class TestWaveInMaterial:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -135,7 +135,7 @@ class TestWaveInMaterial:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -217,7 +217,7 @@ class TestWaveInMaterial:
 
             sim = Simulation(
                 design=design,
-                devices=[source],
+                sources=[source],
                 boundaries=[PML(thickness=wavelength)],
                 time=time,
                 resolution=dx,

--- a/tests/test_physics_pml.py
+++ b/tests/test_physics_pml.py
@@ -71,7 +71,7 @@ class TestPMLAbsorption:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=pml_thickness)],
             time=time,
             resolution=dx,
@@ -134,7 +134,7 @@ class TestPMLAbsorption:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -196,7 +196,7 @@ class TestPMLAbsorption:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=pml_thickness)],
             time=time,
             resolution=dx,
@@ -247,7 +247,7 @@ class TestPMLAbsorption:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,

--- a/tests/test_physics_propagation.py
+++ b/tests/test_physics_propagation.py
@@ -65,7 +65,7 @@ class TestFreeSpacePropagation:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -131,7 +131,7 @@ class TestFreeSpacePropagation:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -191,7 +191,7 @@ class TestFreeSpacePropagation:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,

--- a/tests/test_physics_quantitative.py
+++ b/tests/test_physics_quantitative.py
@@ -127,7 +127,7 @@ class TestFresnelQuantitative:
 
         sim_ref = Simulation(
             design=design_ref,
-            devices=[source_ref, mon_ref],
+            sources=[source_ref], monitors=[mon_ref],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -163,7 +163,7 @@ class TestFresnelQuantitative:
 
         sim_full = Simulation(
             design=design_full,
-            devices=[source_full, mon_trans],
+            sources=[source_full], monitors=[mon_trans],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -244,7 +244,7 @@ class TestFresnelQuantitative:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -397,7 +397,7 @@ class TestModeSourceAccuracy:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.2 * wavelength)],
             time=time,
             resolution=dx,
@@ -479,7 +479,7 @@ class TestGridConvergenceQuantitative:
 
             sim = Simulation(
                 design=design,
-                devices=[source],
+                sources=[source],
                 boundaries=[PML(thickness=wavelength)],
                 time=time,
                 resolution=dx,
@@ -594,7 +594,7 @@ class TestGridConvergenceQuantitative:
 
             sim = Simulation(
                 design=design,
-                devices=[source],
+                sources=[source],
                 boundaries=[PML(thickness=wavelength)],
                 time=time,
                 resolution=dx,
@@ -681,7 +681,7 @@ class TestMieScattering2D:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -772,7 +772,7 @@ class TestMieScattering2D:
         # Run reference
         sim_ref = Simulation(
             design=design_ref,
-            devices=[source_ref],
+            sources=[source_ref],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -782,7 +782,7 @@ class TestMieScattering2D:
         # Run with scatterer
         sim_full = Simulation(
             design=design_full,
-            devices=[source_full],
+            sources=[source_full],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -888,7 +888,7 @@ class TestFabryPerotQuantitative:
 
         sim = Simulation(
             design=design,
-            devices=[source, mon_center],
+            sources=[source], monitors=[mon_center],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -960,7 +960,7 @@ class TestFabryPerotQuantitative:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -1047,7 +1047,7 @@ class TestEnergyConservationQuantitative:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -1105,7 +1105,7 @@ class TestEnergyConservationQuantitative:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -1186,7 +1186,7 @@ class TestPhysics3D:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -1272,7 +1272,7 @@ class TestPhysics3D:
         # Run reference
         sim_ref = Simulation(
             design=design_ref,
-            devices=[source_ref],
+            sources=[source_ref],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -1282,7 +1282,7 @@ class TestPhysics3D:
         # Run with sphere
         sim_full = Simulation(
             design=design_full,
-            devices=[source_full],
+            sources=[source_full],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,

--- a/tests/test_physics_validation.py
+++ b/tests/test_physics_validation.py
@@ -136,7 +136,7 @@ class TestFresnelCoefficients:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -244,7 +244,7 @@ class TestGridConvergenceOrder:
 
             sim = Simulation(
                 design=design,
-                devices=[source],
+                sources=[source],
                 boundaries=[PML(thickness=wavelength)],
                 time=time,
                 resolution=dx,
@@ -320,7 +320,7 @@ class TestGridConvergenceOrder:
 
             sim = Simulation(
                 design=design,
-                devices=[source],
+                sources=[source],
                 boundaries=[PML(thickness=1.5 * wavelength)],
                 time=time,
                 resolution=dx,
@@ -425,7 +425,7 @@ class TestMieScattering:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,
@@ -584,7 +584,7 @@ class TestFabryPerot:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=wavelength)],
             time=time,
             resolution=dx,
@@ -748,7 +748,7 @@ class TestWaveguideEffectiveIndex:
 
         sim = Simulation(
             design=design,
-            devices=[source],
+            sources=[source],
             boundaries=[PML(thickness=1.5 * wavelength)],
             time=time,
             resolution=dx,

--- a/tests/test_simulation_api.py
+++ b/tests/test_simulation_api.py
@@ -89,3 +89,17 @@ def test_run_compiled_returns_simulation_results_with_backward_compatible_mappin
     assert result["monitors"] == [monitor]
     assert "monitor_results" in result
     assert isinstance(result.monitor_results["m1"], MonitorResults)
+
+
+def test_monitor_runtime_state_is_kept_in_private_container():
+    monitor = Monitor(start=(1 * um, 1 * um), end=(1 * um, 3 * um), name="m1")
+
+    assert "_state" in monitor.__dict__
+    assert "power_history" not in monitor.__dict__
+    assert "fields" not in monitor.__dict__
+
+    monitor.power_history = [1.0, 2.0]
+    monitor.fields["t"] = [0.0]
+
+    assert monitor._state.power_history == [1.0, 2.0]
+    assert monitor._state.fields["t"] == [0.0]

--- a/tests/test_simulation_api.py
+++ b/tests/test_simulation_api.py
@@ -103,3 +103,14 @@ def test_monitor_runtime_state_is_kept_in_private_container():
 
     assert monitor._state.power_history == [1.0, 2.0]
     assert monitor._state.fields["t"] == [0.0]
+
+
+def test_source_runtime_state_is_kept_in_private_container():
+    source = GaussianSource(position=(2 * um, 2 * um), width=0.2 * um, signal=[1.0, 0.0])
+
+    assert "_state" in source.__dict__
+    assert "_spatial_profile_ez" not in source.__dict__
+    assert "_grid_indices" not in source.__dict__
+
+    source._grid_indices = (slice(0, 1), slice(0, 1))
+    assert source._state._grid_indices == (slice(0, 1), slice(0, 1))

--- a/tests/test_simulation_api.py
+++ b/tests/test_simulation_api.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pytest
+
+from beamz import Design, GaussianSource, Material, Monitor, Simulation, um
+
+
+def _time_axis():
+    return np.array([0.0, 1e-16, 2e-16], dtype=float)
+
+
+def test_simulation_normalizes_sources_and_monitors_from_explicit_args():
+    design = Design(width=4 * um, height=4 * um, material=Material(permittivity=1.0))
+    source = GaussianSource(position=(2 * um, 2 * um), width=0.2 * um, signal=[1.0, 0.0])
+    monitor = Monitor(start=(1 * um, 1 * um), end=(1 * um, 3 * um), name="m1")
+
+    sim = Simulation(
+        design=design,
+        sources=[source],
+        monitors=[monitor],
+        time=_time_axis(),
+        resolution=0.2 * um,
+    )
+
+    assert sim.sources == [source]
+    assert sim.monitors == [monitor]
+    assert sim.devices == [source, monitor]
+
+
+def test_simulation_normalizes_legacy_devices_into_sources_and_monitors():
+    design = Design(width=4 * um, height=4 * um, material=Material(permittivity=1.0))
+    source = GaussianSource(position=(2 * um, 2 * um), width=0.2 * um, signal=[1.0, 0.0])
+    monitor = Monitor(start=(1 * um, 1 * um), end=(1 * um, 3 * um), name="m1")
+
+    sim = Simulation(
+        design=design,
+        devices=[source, monitor],
+        time=_time_axis(),
+        resolution=0.2 * um,
+    )
+
+    assert sim.sources == [source]
+    assert sim.monitors == [monitor]
+    assert sim.devices == [source, monitor]
+
+
+def test_simulation_falls_back_to_design_devices_with_deprecation_warning():
+    design = Design(width=4 * um, height=4 * um, material=Material(permittivity=1.0))
+    source = GaussianSource(position=(2 * um, 2 * um), width=0.2 * um, signal=[1.0, 0.0])
+    monitor = Monitor(start=(1 * um, 1 * um), end=(1 * um, 3 * um), name="m1")
+    design += source
+    design += monitor
+
+    with pytest.deprecated_call(match="Passing sources and monitors via Design is deprecated"):
+        sim = Simulation(
+            design=design,
+            time=_time_axis(),
+            resolution=0.2 * um,
+        )
+
+    assert sim.sources == [source]
+    assert sim.monitors == [monitor]
+    assert sim.devices == [source, monitor]

--- a/tests/test_simulation_api.py
+++ b/tests/test_simulation_api.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+
 from beamz import (
     Design,
     GaussianSource,
@@ -46,6 +48,20 @@ def test_simulation_accepts_explicit_sources_and_monitors():
 
     assert sim.sources == [source]
     assert sim.monitors == [monitor]
+
+
+def test_simulation_rejects_duplicate_named_monitors():
+    design = Design(width=4 * um, height=4 * um, material=Material(permittivity=1.0))
+    m1 = Monitor(start=(1 * um, 1 * um), end=(1 * um, 3 * um), name="port")
+    m2 = Monitor(start=(2 * um, 1 * um), end=(2 * um, 3 * um), name="port")
+
+    with pytest.raises(ValueError, match="Simulation\\._normalize_specs.*port"):
+        Simulation(
+            design=design,
+            monitors=[m1, m2],
+            time=_time_axis(),
+            resolution=0.2 * um,
+        )
 
 
 def test_design_rejects_device_objects():

--- a/tests/test_simulation_api.py
+++ b/tests/test_simulation_api.py
@@ -1,6 +1,4 @@
 import numpy as np
-import pytest
-
 from beamz import (
     Design,
     GaussianSource,
@@ -50,22 +48,24 @@ def test_simulation_accepts_explicit_sources_and_monitors():
     assert sim.monitors == [monitor]
 
 
-def test_simulation_falls_back_to_design_devices_with_deprecation_warning():
+def test_design_rejects_device_objects():
     design = Design(width=4 * um, height=4 * um, material=Material(permittivity=1.0))
     source = GaussianSource(position=(2 * um, 2 * um), width=0.2 * um, signal=[1.0, 0.0])
     monitor = Monitor(start=(1 * um, 1 * um), end=(1 * um, 3 * um), name="m1")
-    design += source
-    design += monitor
 
-    with pytest.deprecated_call(match="Passing sources and monitors via Design is deprecated"):
-        sim = Simulation(
-            design=design,
-            time=_time_axis(),
-            resolution=0.2 * um,
-        )
+    try:
+        design += source
+    except TypeError as exc:
+        assert "Simulation(sources=[...])" in str(exc)
+    else:
+        raise AssertionError("Expected Design to reject source objects")
 
-    assert sim.sources == [source]
-    assert sim.monitors == [monitor]
+    try:
+        design += monitor
+    except TypeError as exc:
+        assert "Simulation(monitors=[...])" in str(exc)
+    else:
+        raise AssertionError("Expected Design to reject monitor objects")
 
 
 def test_run_compiled_returns_simulation_results_with_backward_compatible_mapping():

--- a/tests/test_simulation_api.py
+++ b/tests/test_simulation_api.py
@@ -32,24 +32,22 @@ def test_simulation_normalizes_sources_and_monitors_from_explicit_args():
 
     assert sim.sources == [source]
     assert sim.monitors == [monitor]
-    assert sim.devices == [source, monitor]
 
 
-def test_simulation_normalizes_legacy_devices_into_sources_and_monitors():
+def test_simulation_accepts_explicit_sources_and_monitors():
     design = Design(width=4 * um, height=4 * um, material=Material(permittivity=1.0))
     source = GaussianSource(position=(2 * um, 2 * um), width=0.2 * um, signal=[1.0, 0.0])
     monitor = Monitor(start=(1 * um, 1 * um), end=(1 * um, 3 * um), name="m1")
 
     sim = Simulation(
         design=design,
-        devices=[source, monitor],
+        sources=[source], monitors=[monitor],
         time=_time_axis(),
         resolution=0.2 * um,
     )
 
     assert sim.sources == [source]
     assert sim.monitors == [monitor]
-    assert sim.devices == [source, monitor]
 
 
 def test_simulation_falls_back_to_design_devices_with_deprecation_warning():
@@ -68,7 +66,6 @@ def test_simulation_falls_back_to_design_devices_with_deprecation_warning():
 
     assert sim.sources == [source]
     assert sim.monitors == [monitor]
-    assert sim.devices == [source, monitor]
 
 
 def test_run_compiled_returns_simulation_results_with_backward_compatible_mapping():

--- a/tests/test_simulation_api.py
+++ b/tests/test_simulation_api.py
@@ -1,7 +1,16 @@
 import numpy as np
 import pytest
 
-from beamz import Design, GaussianSource, Material, Monitor, Simulation, um
+from beamz import (
+    Design,
+    GaussianSource,
+    Material,
+    Monitor,
+    MonitorResults,
+    Simulation,
+    SimulationResults,
+    um,
+)
 
 
 def _time_axis():
@@ -60,3 +69,23 @@ def test_simulation_falls_back_to_design_devices_with_deprecation_warning():
     assert sim.sources == [source]
     assert sim.monitors == [monitor]
     assert sim.devices == [source, monitor]
+
+
+def test_run_compiled_returns_simulation_results_with_backward_compatible_mapping():
+    design = Design(width=4 * um, height=4 * um, material=Material(permittivity=1.0))
+    source = GaussianSource(position=(2 * um, 2 * um), width=0.2 * um, signal=[1.0, 0.0, 0.0])
+    monitor = Monitor(start=(1 * um, 1 * um), end=(1 * um, 3 * um), name="m1")
+
+    sim = Simulation(
+        design=design,
+        sources=[source],
+        monitors=[monitor],
+        time=np.array([0.0, 1e-16, 2e-16, 3e-16], dtype=float),
+        resolution=0.2 * um,
+    )
+    result = sim.run_compiled(progress=False)
+
+    assert isinstance(result, SimulationResults)
+    assert result["monitors"] == [monitor]
+    assert "monitor_results" in result
+    assert isinstance(result.monitor_results["m1"], MonitorResults)

--- a/tests/test_visual_scene.py
+++ b/tests/test_visual_scene.py
@@ -100,12 +100,8 @@ class FakeMonitorX:
 
 
 def _make_design():
-    source = FakeModeSource()
-    monitor = FakeMonitor()
     return SimpleNamespace(
         structures=[FakeStructure()],
-        sources=[source],
-        monitors=[monitor],
         width=2.0,
         height=1.0,
         depth=0.22,
@@ -114,15 +110,11 @@ def _make_design():
 
 
 def _make_design_with_repeated_material():
-    source = FakeModeSource()
-    monitor = FakeMonitor()
     return SimpleNamespace(
         structures=[
             FakeStructureTwin(x_offset=0.0, color="#2563eb"),
             FakeStructureTwin(x_offset=2.5, color="#f97316"),
         ],
-        sources=[source],
-        monitors=[monitor],
         width=5.0,
         height=1.0,
         depth=0.22,
@@ -131,15 +123,11 @@ def _make_design_with_repeated_material():
 
 
 def _make_design_with_overlapping_material():
-    source = FakeModeSource()
-    monitor = FakeMonitor()
     return SimpleNamespace(
         structures=[
             FakeStructureTwin(x_offset=0.0, color="#2563eb"),
             FakeStructureTwin(x_offset=1.0, color="#f97316"),
         ],
-        sources=[source],
-        monitors=[monitor],
         width=4.0,
         height=1.0,
         depth=0.22,
@@ -148,8 +136,6 @@ def _make_design_with_overlapping_material():
 
 
 def _make_design_with_two_materials_and_air():
-    source = FakeModeSource()
-    monitor = FakeMonitor()
     air = FakeAirStructure(x_offset=4.5)
     return SimpleNamespace(
         structures=[
@@ -157,8 +143,6 @@ def _make_design_with_two_materials_and_air():
             FakeStructureTwin(x_offset=2.5),
             air,
         ],
-        sources=[source],
-        monitors=[monitor],
         width=7.0,
         height=1.0,
         depth=0.22,
@@ -168,11 +152,13 @@ def _make_design_with_two_materials_and_air():
 
 def _make_simulation():
     design = _make_design()
+    primary_source = FakeModeSource()
+    primary_monitor = FakeMonitor()
     extra_source = FakeGaussianSource()
     sim = Simulation.__new__(Simulation)
     sim.design = design
-    sim.sources = [design.sources[0], extra_source]
-    sim.monitors = [design.monitors[0]]
+    sim.sources = [primary_source, extra_source]
+    sim.monitors = [primary_monitor]
     sim.boundaries = [PML(edges=["left", "right"], thickness=0.15)]
     sim.resolution = 2.5e-8
     sim.is_3d = True
@@ -247,11 +233,11 @@ def test_simulation_to_scene_includes_devices_boundaries_and_metadata():
 
 def test_simulation_to_scene_preserves_monitor_extents_for_x_normal_planes():
     design = _make_design()
-    design.monitors = [FakeMonitorX()]
+    monitor = FakeMonitorX()
     sim = Simulation.__new__(Simulation)
     sim.design = design
     sim.sources = []
-    sim.monitors = [design.monitors[0]]
+    sim.monitors = [monitor]
     sim.boundaries = []
     sim.resolution = 2.5e-8
     sim.is_3d = True
@@ -279,7 +265,6 @@ def test_simulation_to_scene_preserves_monitor_center_for_legacy_plane_monitors(
         size=(0.8, 0.4),
         name="legacy_flux",
     )
-    design.monitors = [legacy_monitor]
     sim = Simulation.__new__(Simulation)
     sim.design = design
     sim.sources = []
@@ -322,10 +307,11 @@ def test_simulation_show_delegates_to_view3d(monkeypatch):
 
 def test_mode_source_visualization_does_not_emit_direction_arrow():
     design = _make_design()
-    design.sources[0].wavelength = 99.0
+    source = FakeModeSource()
+    source.wavelength = 99.0
     sim = Simulation.__new__(Simulation)
     sim.design = design
-    sim.sources = [design.sources[0]]
+    sim.sources = [source]
     sim.monitors = []
     sim.boundaries = []
     sim.resolution = 2.5e-8

--- a/tests/test_visual_scene.py
+++ b/tests/test_visual_scene.py
@@ -171,7 +171,8 @@ def _make_simulation():
     extra_source = FakeGaussianSource()
     sim = Simulation.__new__(Simulation)
     sim.design = design
-    sim.devices = [design.sources[0], design.monitors[0], extra_source]
+    sim.sources = [design.sources[0], extra_source]
+    sim.monitors = [design.monitors[0]]
     sim.boundaries = [PML(edges=["left", "right"], thickness=0.15)]
     sim.resolution = 2.5e-8
     sim.is_3d = True
@@ -249,7 +250,8 @@ def test_simulation_to_scene_preserves_monitor_extents_for_x_normal_planes():
     design.monitors = [FakeMonitorX()]
     sim = Simulation.__new__(Simulation)
     sim.design = design
-    sim.devices = [design.monitors[0]]
+    sim.sources = []
+    sim.monitors = [design.monitors[0]]
     sim.boundaries = []
     sim.resolution = 2.5e-8
     sim.is_3d = True
@@ -280,7 +282,8 @@ def test_simulation_to_scene_preserves_monitor_center_for_legacy_plane_monitors(
     design.monitors = [legacy_monitor]
     sim = Simulation.__new__(Simulation)
     sim.design = design
-    sim.devices = [legacy_monitor]
+    sim.sources = []
+    sim.monitors = [legacy_monitor]
     sim.boundaries = []
     sim.resolution = 2.5e-8
     sim.is_3d = True
@@ -322,7 +325,8 @@ def test_mode_source_visualization_does_not_emit_direction_arrow():
     design.sources[0].wavelength = 99.0
     sim = Simulation.__new__(Simulation)
     sim.design = design
-    sim.devices = [design.sources[0]]
+    sim.sources = [design.sources[0]]
+    sim.monitors = []
     sim.boundaries = []
     sim.resolution = 2.5e-8
     sim.is_3d = True
@@ -341,7 +345,7 @@ def test_design_to_scene_keeps_adjacent_same_material_structures_separate():
     scene = simulation_to_scene(
         SimpleNamespace(
             design=_make_design_with_repeated_material(),
-            devices=[],
+            sources=[], monitors=[],
             boundaries=[],
             resolution=2.5e-8,
             is_3d=True,
@@ -373,7 +377,7 @@ def test_design_to_scene_includes_sphere_structures():
                 depth=0.6,
                 is_3d=True,
             ),
-            devices=[],
+            sources=[], monitors=[],
             boundaries=[],
             resolution=2.5e-8,
             is_3d=True,
@@ -402,7 +406,7 @@ def test_design_to_scene_unions_overlapping_same_material_structures():
     scene = simulation_to_scene(
         SimpleNamespace(
             design=_make_design_with_overlapping_material(),
-            devices=[],
+            sources=[], monitors=[],
             boundaries=[],
             resolution=2.5e-8,
             is_3d=True,
@@ -426,7 +430,7 @@ def test_structure_colors_are_deterministic_and_only_air_is_transparent():
     scene = simulation_to_scene(
         SimpleNamespace(
             design=_make_design_with_two_materials_and_air(),
-            devices=[],
+            sources=[], monitors=[],
             boundaries=[],
             resolution=2.5e-8,
             is_3d=True,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured simulation outputs: MonitorResults and SimulationResults available at the top-level API.
  * Visualization/animation now accept explicit sources and monitors for overlay control.
  * Examples and tooling updated to use explicit sources/monitors parameters.

* **Breaking Changes**
  * Simulation constructor now takes separate sources and monitors parameters (replacing devices).
  * Design.add() rejects sources/monitors; only geometry structures are accepted.
  * Simulation.run()/run_compiled() return SimulationResults instead of plain dicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->