### PR TITLE
[Refactor]: Update the PML names to AbsorbingLayer & Sponge

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install beamz
 - **GPU-accelerated** (but CPU-capable).
 - Built-in layout flow (GDSII import/export).
 - FDTD simulation in 2D and **3D**.
-- PML, CPML (WIP), and PEC boundaries.
+- Absorbing Layers, CPML (WIP), and PEC boundaries.
 - **Sub-pixel smoothing** (using super-sampling).
 - Gaussian and **mode sources** with TE and TM polarization.
 - Custom source time profiles.

--- a/beamz/__init__.py
+++ b/beamz/__init__.py
@@ -42,7 +42,7 @@ from beamz.optimization.topology import (
     compute_overlap_gradient,
     create_optimization_mask,
 )
-from beamz.simulation.boundaries import PEC, PML, Boundary
+from beamz.simulation.boundaries import AbsorbingLayer, PEC, PML, Boundary
 from beamz.simulation.compiled import (
     CompiledRunConfig,
     CompiledSimulation,
@@ -116,6 +116,7 @@ _exports = {
     "compile_simulation": compile_simulation,
     # Boundaries
     "Boundary": Boundary,
+    "AbsorbingLayer": AbsorbingLayer,
     "PML": PML,
     "PEC": PEC,
     # Optimization

--- a/beamz/simulation/boundaries.py
+++ b/beamz/simulation/boundaries.py
@@ -12,6 +12,23 @@ from beamz.simulation.yee import (
 )
 
 
+def _canonicalize_pml_formulation(formulation):
+    """Normalize public absorber/PML formulation names."""
+
+    normalized = str(formulation).lower()
+    aliases = {
+        "sigma": "sponge",
+        "sponge": "sponge",
+        "cpml": "cpml",
+    }
+    if normalized not in aliases:
+        raise ValueError(
+            "Unsupported boundary formulation "
+            f"{formulation!r}. Expected one of: 'sponge', 'sigma', 'cpml'."
+        )
+    return aliases[normalized]
+
+
 class Boundary:
     """Abstract base class for all boundary conditions."""
 
@@ -43,8 +60,9 @@ class Boundary:
 class PML(Boundary):
     """Perfectly Matched Layer boundary condition.
 
-    BeamZ defaults to the graded-conductivity absorber via
-    ``formulation="sigma"``. The optional ``formulation="cpml"`` path exposes
+    BeamZ keeps this class for backwards compatibility, but the default
+    formulation is a graded-conductivity absorbing layer exposed as
+    ``formulation="sponge"``. The optional ``formulation="cpml"`` path exposes
     the additional ``sigma/kappa/alpha`` profiles needed for a true
     convolutional PML in the solver update equations.
     """
@@ -57,7 +75,7 @@ class PML(Boundary):
         thickness=1 * µm,
         sigma_max=None,
         m=3,
-        formulation="sigma",
+        formulation="sponge",
         kappa_max=3.0,
         alpha_max=None,
         target_reflection=1e-6,
@@ -68,13 +86,14 @@ class PML(Boundary):
             thickness: PML thickness
             sigma_max: maximum conductivity (auto-calculated if None)
             m: conductivity grading order
-            formulation: ``"sigma"`` for the default graded-conductivity
-                absorber or ``"cpml"`` for the convolutional PML
+            formulation: ``"sponge"`` for the default graded-conductivity
+                absorber, ``"sigma"`` as a backwards-compatible alias, or
+                ``"cpml"`` for the convolutional PML
         """
         super().__init__(edges, thickness)
         self.sigma_max = sigma_max
         self.m = m
-        self.formulation = str(formulation).lower()
+        self.formulation = _canonicalize_pml_formulation(formulation)
         self.kappa_max = float(kappa_max)
         self.alpha_max = None if alpha_max is None else float(alpha_max)
         self.target_reflection = float(target_reflection)
@@ -331,7 +350,7 @@ class PML(Boundary):
         return sigma, kappa, alpha
 
     def _create_pml_profiles_2d(self, fields, design, plane_2d):
-        """Create graded-sigma PML profiles for 2D plane."""
+        """Create graded-conductivity absorber profiles for a 2D plane."""
         shape = fields.permittivity.shape
         dim1, dim2 = shape
 
@@ -371,10 +390,10 @@ class PML(Boundary):
         }
 
         pml_mask = (sigma_axis1 > 0) | (sigma_axis2 > 0)
-        return {"mask": pml_mask, **profiles}
+        return {"formulation": "sponge", "mask": pml_mask, **profiles}
 
     def _create_pml_profiles_3d(self, fields, design):
-        """Create graded-sigma PML profiles for 3D."""
+        """Create graded-conductivity absorber profiles for 3D."""
         shape = fields.permittivity.shape  # (nz, ny, nx)
         nz, ny, nx = shape
         depth, height, width = design.depth, design.height, design.width
@@ -406,7 +425,7 @@ class PML(Boundary):
         }
 
         pml_mask = (sigma_x > 0) | (sigma_y > 0) | (sigma_z > 0)
-        return {"mask": pml_mask, **profiles}
+        return {"formulation": "sponge", "mask": pml_mask, **profiles}
 
     def _create_cpml_profiles_2d(self, fields, design, plane_2d):
         """Create sigma/kappa/alpha CPML profiles for 2D."""
@@ -656,6 +675,31 @@ class PML(Boundary):
             }
         )
         return out
+
+
+class AbsorbingLayer(PML):
+    """Legacy graded-conductivity absorbing layer.
+
+    This boundary adds loss by merging a graded conductivity shell into the
+    material conductivity update. It is not a matched-layer formulation.
+    """
+
+    def __init__(
+        self,
+        edges="all",
+        thickness=1 * µm,
+        sigma_max=None,
+        m=3,
+        target_reflection=1e-6,
+    ):
+        super().__init__(
+            edges=edges,
+            thickness=thickness,
+            sigma_max=sigma_max,
+            m=m,
+            formulation="sponge",
+            target_reflection=target_reflection,
+        )
 
 
 class PEC(Boundary):

--- a/beamz/simulation/fields.py
+++ b/beamz/simulation/fields.py
@@ -107,7 +107,7 @@ class Fields:
     def set_pml_conductivity(self, pml_data):
         """Set effective conductivity for PML regions."""
         self.has_pml = True
-        self.has_cpml = str(pml_data.get("formulation", "sigma")).lower() == "cpml"
+        self.has_cpml = str(pml_data.get("formulation", "sponge")).lower() == "cpml"
         # Convert PML data arrays to JAX
         self.pml_data = {
             k: jnp.asarray(v) if hasattr(v, "__array__") else v

--- a/examples/benchmarks/2_pml_validation/dipole_radiation_symmetry_3d.py
+++ b/examples/benchmarks/2_pml_validation/dipole_radiation_symmetry_3d.py
@@ -303,7 +303,7 @@ def _plot(results: list[Result], out_dir: Path) -> Path:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output-dir", type=Path, default=SCRIPT_DIR / "results_dipole_radiation_symmetry_3d")
-    parser.add_argument("--formulations", type=str, default="sigma,cpml")
+    parser.add_argument("--formulations", type=str, default="sponge,cpml")
     parser.add_argument("--pml-thicknesses-wl", type=str, default="1.0")
     parser.add_argument("--cpml-kappa-values", type=str, default="4.0,6.0")
     parser.add_argument("--cpml-alpha-values", type=str, default="300.0,150.0")

--- a/examples/benchmarks/2_pml_validation/oblique_plane_wave_pml_sweep.py
+++ b/examples/benchmarks/2_pml_validation/oblique_plane_wave_pml_sweep.py
@@ -309,7 +309,7 @@ def _plot_probe_trace(debug: dict, out_dir: Path, *, formulation: str, thickness
 def main() -> None:
     parser = argparse.ArgumentParser(description="Sweep oblique plane-wave reflection versus absorber thickness.")
     parser.add_argument("--output-dir", type=Path, default=SCRIPT_DIR / "results_oblique_plane_wave_pml_sweep")
-    parser.add_argument("--formulations", type=str, default="sigma,cpml")
+    parser.add_argument("--formulations", type=str, default="sponge,cpml")
     parser.add_argument("--pml-thicknesses-wl", type=str, default="0.5,1.0,1.5")
     parser.add_argument("--angle-deg", type=float, default=SweepConfig().angle_deg)
     parser.add_argument("--cpml-kappa-max", type=float, default=SweepConfig().cpml_kappa_max)

--- a/examples/benchmarks/2_pml_validation/plane_wave_pml_sweep.py
+++ b/examples/benchmarks/2_pml_validation/plane_wave_pml_sweep.py
@@ -342,7 +342,7 @@ def main() -> None:
     parser.add_argument(
         "--formulations",
         type=str,
-        default="sigma,cpml",
+        default="sponge,cpml",
         help="Comma-separated formulations to compare.",
     )
     parser.add_argument(

--- a/examples/benchmarks/2_pml_validation/plane_wave_pml_sweep_3d.py
+++ b/examples/benchmarks/2_pml_validation/plane_wave_pml_sweep_3d.py
@@ -333,7 +333,7 @@ def _plot_probe_trace(debug: dict, out_dir: Path, *, formulation: str, thickness
 def main() -> None:
     parser = argparse.ArgumentParser(description="Sweep 3D normal-incidence plane-wave reflection versus absorber thickness.")
     parser.add_argument("--output-dir", type=Path, default=SCRIPT_DIR / "results_plane_wave_pml_sweep_3d")
-    parser.add_argument("--formulations", type=str, default="sigma,cpml")
+    parser.add_argument("--formulations", type=str, default="sponge,cpml")
     parser.add_argument("--pml-thicknesses-wl", type=str, default="0.5,1.0,1.5")
     parser.add_argument("--cpml-kappa-max", type=float, default=SweepConfig().cpml_kappa_max)
     parser.add_argument("--cpml-alpha-max", type=float, default=SweepConfig().cpml_alpha_max)

--- a/examples/benchmarks/2_pml_validation/radiating_source_pml_sweep.py
+++ b/examples/benchmarks/2_pml_validation/radiating_source_pml_sweep.py
@@ -185,7 +185,7 @@ def _plot_energy_trace(debug: dict, out_dir: Path, *, formulation: str, thicknes
 def main() -> None:
     parser = argparse.ArgumentParser(description="Sweep radiating-source residual energy versus absorber thickness.")
     parser.add_argument("--output-dir", type=Path, default=SCRIPT_DIR / "results_radiating_source_pml_sweep")
-    parser.add_argument("--formulations", type=str, default="sigma,cpml")
+    parser.add_argument("--formulations", type=str, default="sponge,cpml")
     parser.add_argument("--pml-thicknesses-wl", type=str, default="0.5,1.0,1.5,2.0")
     parser.add_argument("--cpml-kappa-max", type=float, default=SweepConfig().cpml_kappa_max)
     parser.add_argument("--cpml-alpha-max", type=float, default=SweepConfig().cpml_alpha_max)

--- a/examples/benchmarks/2_pml_validation/radiating_source_pml_sweep_3d.py
+++ b/examples/benchmarks/2_pml_validation/radiating_source_pml_sweep_3d.py
@@ -171,7 +171,7 @@ def _plot_results(results: list[CaseResult], out_dir: Path):
 def main() -> None:
     parser = argparse.ArgumentParser(description="Sweep 3D radiating-source residual energy versus absorber thickness.")
     parser.add_argument("--output-dir", type=Path, default=SCRIPT_DIR / "results_radiating_source_pml_sweep_3d")
-    parser.add_argument("--formulations", type=str, default="sigma,cpml")
+    parser.add_argument("--formulations", type=str, default="sponge,cpml")
     parser.add_argument("--pml-thicknesses-wl", type=str, default="0.5,1.0,1.5")
     parser.add_argument("--cpml-kappa-max", type=float, default=SweepConfig().cpml_kappa_max)
     parser.add_argument("--cpml-alpha-max", type=float, default=SweepConfig().cpml_alpha_max)

--- a/examples/benchmarks/2_pml_validation/simple_waveguide_transmission_3d.py
+++ b/examples/benchmarks/2_pml_validation/simple_waveguide_transmission_3d.py
@@ -282,7 +282,7 @@ def _plot(results: list[Result], out_dir: Path) -> Path:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--output-dir", type=Path, default=SCRIPT_DIR / "results_simple_waveguide_transmission_3d")
-    parser.add_argument("--formulations", type=str, default="sigma,cpml")
+    parser.add_argument("--formulations", type=str, default="sponge,cpml")
     args = parser.parse_args()
 
     cfg = Config(formulations=tuple(tok.strip() for tok in args.formulations.split(",") if tok.strip()))

--- a/examples/benchmarks/2_pml_validation/source_port_s11_spacing_sweep_3d.py
+++ b/examples/benchmarks/2_pml_validation/source_port_s11_spacing_sweep_3d.py
@@ -14,7 +14,7 @@ fixed source/reference plane and reports:
 - transmission/cross-port center-frequency values for sanity
 
 The defaults intentionally use a low-cost configuration:
-- sigma absorber only
+- sponge absorber only
 - 3D
 - 6 PPW
 """
@@ -652,7 +652,7 @@ def build_straight_case(cfg: SweepConfig, monitor_delta_um: float):
         design=design,
         sources=[source],
         monitors=monitors,
-        boundaries=[PML(edges="all", thickness=cfg.pml_m, formulation="sigma")],
+        boundaries=[PML(edges="all", thickness=cfg.pml_m, formulation="sponge")],
         time=pulse.time,
         resolution=dx,
     )
@@ -856,8 +856,8 @@ def build_crossing_case(cfg: SweepConfig, monitor_delta_um: float):
         sources=[source],
         monitors=monitors,
         boundaries=[
-            PML(edges=["left", "right", "top", "bottom"], thickness=cfg.pml_m, formulation="sigma"),
-            PML(edges=["front", "back"], thickness=cfg.pml_m, formulation="sigma"),
+            PML(edges=["left", "right", "top", "bottom"], thickness=cfg.pml_m, formulation="sponge"),
+            PML(edges=["front", "back"], thickness=cfg.pml_m, formulation="sponge"),
         ],
         time=pulse.time,
         resolution=dx,

--- a/examples/benchmarks/2_pml_validation/straight_waveguide_field_symmetry_3d.py
+++ b/examples/benchmarks/2_pml_validation/straight_waveguide_field_symmetry_3d.py
@@ -517,8 +517,8 @@ def run_case(
         sources=[source],
         monitors=[monitor],
         boundaries=[
-            PML(edges=["left", "right", "top", "bottom"], thickness=cfg.pml_m, formulation="sigma"),
-            PML(edges=["front", "back"], thickness=cfg.pml_m, formulation="sigma"),
+            PML(edges=["left", "right", "top", "bottom"], thickness=cfg.pml_m, formulation="sponge"),
+            PML(edges=["front", "back"], thickness=cfg.pml_m, formulation="sponge"),
         ],
         time=time,
         resolution=dx,

--- a/examples/benchmarks/2_pml_validation/straight_waveguide_pml_sweep.py
+++ b/examples/benchmarks/2_pml_validation/straight_waveguide_pml_sweep.py
@@ -455,7 +455,7 @@ def main() -> None:
     parser.add_argument(
         "--formulation",
         type=str,
-        default="sigma",
+        default="sponge",
         choices=("sigma", "cpml"),
         help="Boundary absorber formulation to benchmark.",
     )

--- a/examples/benchmarks/2_pml_validation/straight_waveguide_step_symmetry_3d.py
+++ b/examples/benchmarks/2_pml_validation/straight_waveguide_step_symmetry_3d.py
@@ -101,8 +101,8 @@ def _run_history_case(cfg: HistoryConfig) -> dict[str, object]:
         sources=[source],
         monitors=[],
         boundaries=[
-            PML(edges=["left", "right", "top", "bottom"], thickness=base_cfg.pml_m, formulation="sigma"),
-            PML(edges=["front", "back"], thickness=base_cfg.pml_m, formulation="sigma"),
+            PML(edges=["left", "right", "top", "bottom"], thickness=base_cfg.pml_m, formulation="sponge"),
+            PML(edges=["front", "back"], thickness=base_cfg.pml_m, formulation="sponge"),
         ],
         time=time,
         resolution=dx,

--- a/examples/compact_models/tiny_beamz_crossing.py
+++ b/examples/compact_models/tiny_beamz_crossing.py
@@ -58,7 +58,7 @@ OUTPUT_MONITOR_OFFSET = 0.05 * µm
 RUN_AFTER_SOURCES_UOC = 90.0
 DECAY_RATIO = 1e-4
 LOOKBACK_RECORDS = 20
-# The current CPML path underperforms the legacy sigma absorber on BeamZ's
+# The current CPML path underperforms the legacy sponge absorber on BeamZ's
 # live normal-incidence and oblique PML benchmarks, so keep this example on the
 # more reliable absorber until CPML is corrected.
 PML_FORMULATION = "sigma"

--- a/examples/optimization/0_ceviche_bend.py
+++ b/examples/optimization/0_ceviche_bend.py
@@ -18,7 +18,7 @@ DX, DT = calc_optimal_fdtd_params(WL, 2.25, points_per_wavelength=20) # reduce t
 STEPS = 50 # reduce to 40 for faster optimization
 MAT_PENALTY = 0.3      # Target core material fraction (0.0 to 1.0)
 PENALTY_STRENGTH = 1 # Scaling factor for the penalty gradient
-PML_FORMULATION_2D = "sigma"
+PML_FORMULATION_2D = "sponge"
 
 # Design & Materials
 design = Design(width=W, height=H, material=Material(permittivity=N_CLAD**2))

--- a/tests/test_mode_source.py
+++ b/tests/test_mode_source.py
@@ -1708,7 +1708,7 @@ class TestModeSourceDirectionality3D:
             design=design,
             sources=[source],
             monitors=monitors,
-            boundaries=[PML(thickness=0.8 * wavelength, formulation="sigma")],
+            boundaries=[PML(thickness=0.8 * wavelength, formulation="sponge")],
             time=time,
             resolution=dx,
         )
@@ -1859,7 +1859,7 @@ class TestModeSourceDirectionality3D:
                 design=design,
                 sources=[source],
                 monitors=monitors,
-                boundaries=[PML(thickness=pml, formulation="sigma")],
+                boundaries=[PML(thickness=pml, formulation="sponge")],
                 time=time,
                 resolution=dx,
             )

--- a/tests/test_physics_pml.py
+++ b/tests/test_physics_pml.py
@@ -1,7 +1,7 @@
-"""Physics validation tests for PML (Perfectly Matched Layer) boundaries.
+"""Physics validation tests for absorbing-layer and CPML boundaries.
 
 Tests verify:
-1. PML absorbs outgoing waves with minimal reflection
+1. The graded absorber reduces outgoing-wave reflections
 2. Energy decays monotonically after source stops
 """
 
@@ -79,7 +79,7 @@ class TestPMLAbsorption:
         assert float(np.max(sigma_shell)) > 0.0
         np.testing.assert_allclose(total_sigma, np.asarray(sim.fields.conductivity))
 
-    def test_sigma_pml_still_contributes_loss_in_material_updates(
+    def test_sponge_absorber_still_contributes_loss_in_material_updates(
         self, vacuum_domain_small
     ):
         design = vacuum_domain_small["design"]
@@ -90,7 +90,7 @@ class TestPMLAbsorption:
         sim = Simulation(
             design=design,
             sources=[],
-            boundaries=[PML(thickness=wavelength, formulation="sigma")],
+            boundaries=[PML(thickness=wavelength, formulation="sponge")],
             time=np.array([0.0, dt], dtype=float),
             resolution=dx,
         )
@@ -102,6 +102,7 @@ class TestPMLAbsorption:
 
         assert float(np.max(sigma_shell)) > 0.0
         assert float(np.max(total_sigma)) >= float(np.max(sigma_shell))
+        assert sim.pml_data["formulation"] == "sponge"
 
     def test_cpml_default_alpha_is_nonzero_when_omitted(self, vacuum_domain_small):
         design = vacuum_domain_small["design"]

--- a/tests/unit/objects/boundaries/test_perfectly_matched_layer.py
+++ b/tests/unit/objects/boundaries/test_perfectly_matched_layer.py
@@ -2,7 +2,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from beamz import PML, Design, Material, um
+from beamz import AbsorbingLayer, PML, Design, Material, um
 from beamz.simulation.fields import Fields
 
 pytestmark = pytest.mark.unit
@@ -57,7 +57,7 @@ def test_pml_parameter_defaults():
     assert pml.thickness == pytest.approx(1.0 * um)
     assert pml.sigma_max is None
     assert pml.m == 3
-    assert pml.formulation == "sigma"
+    assert pml.formulation == "sponge"
     assert pml.kappa_max == pytest.approx(3.0)
     assert pml.alpha_max is None
     assert pml.target_reflection == pytest.approx(1e-6)
@@ -66,7 +66,7 @@ def test_pml_parameter_defaults():
 def test_sigma_max_is_computed_when_omitted():
     fields = _make_fields_2d()
     design = _make_design_2d()
-    pml = PML(thickness=0.2, sigma_max=None, formulation="sigma")
+    pml = PML(thickness=0.2, sigma_max=None, formulation="sponge")
 
     payload = pml.create_pml_regions(
         fields, design, resolution=0.1, dt=1e-15, plane_2d="xy"
@@ -77,6 +77,19 @@ def test_sigma_max_is_computed_when_omitted():
     assert payload["sigma_x"].shape == fields.permittivity.shape
     assert payload["sigma_y"].shape == fields.permittivity.shape
     assert payload["mask"].shape == fields.permittivity.shape
+    assert payload["formulation"] == "sponge"
+
+
+def test_absorbing_layer_uses_sponge_formulation():
+    absorber = AbsorbingLayer(thickness=0.2, sigma_max=5.0)
+
+    assert absorber.formulation == "sponge"
+
+
+def test_sigma_alias_maps_to_sponge():
+    pml = PML(formulation="sigma")
+
+    assert pml.formulation == "sponge"
 
 
 def test_cpml_alpha_is_computed_when_omitted():

--- a/tests/unit/utils/test_extend_pml.py
+++ b/tests/unit/utils/test_extend_pml.py
@@ -1,7 +1,7 @@
-"""BeamZ-native equivalent of low-level PML material coupling tests.
+"""BeamZ-native equivalent of low-level absorber/PML material coupling tests.
 
 BeamZ does not copy material tensors into a separate PML extension region. Its
-equivalent contract is how PML conductivity shells merge into
+equivalent contract is how the graded absorbing shell merges into
 ``Fields.total_conductivity`` while CPML leaves the base material update
 conductivity unchanged.
 """
@@ -9,7 +9,7 @@ conductivity unchanged.
 import numpy as np
 import pytest
 
-from beamz import Design, Material, PML
+from beamz import AbsorbingLayer, Design, Material, PML
 from beamz.simulation.fields import Fields
 
 pytestmark = pytest.mark.unit
@@ -47,10 +47,10 @@ def _attach_pml(fields, pml, design, *, resolution=0.1, dt=1e-15):
     return payload
 
 
-def test_sigma_pml_merges_left_shell_into_total_conductivity():
+def test_absorbing_layer_merges_left_shell_into_total_conductivity():
     fields = _make_fields()
     design = _make_design()
-    pml = PML(edges=["left"], thickness=0.2, sigma_max=6.0, formulation="sigma")
+    pml = AbsorbingLayer(edges=["left"], thickness=0.2, sigma_max=6.0)
 
     payload = _attach_pml(fields, pml, design)
     total_sigma = np.asarray(fields.total_conductivity, dtype=np.float64)
@@ -64,10 +64,10 @@ def test_sigma_pml_merges_left_shell_into_total_conductivity():
     assert float(np.max(total_sigma[:, -1])) == pytest.approx(0.0)
 
 
-def test_sigma_pml_merges_right_shell_into_total_conductivity():
+def test_absorbing_layer_merges_right_shell_into_total_conductivity():
     fields = _make_fields()
     design = _make_design()
-    pml = PML(edges=["right"], thickness=0.2, sigma_max=6.0, formulation="sigma")
+    pml = AbsorbingLayer(edges=["right"], thickness=0.2, sigma_max=6.0)
 
     payload = _attach_pml(fields, pml, design)
     total_sigma = np.asarray(fields.total_conductivity, dtype=np.float64)
@@ -79,11 +79,11 @@ def test_sigma_pml_merges_right_shell_into_total_conductivity():
     assert float(np.max(total_sigma[:, 0])) == pytest.approx(0.0)
 
 
-def test_sigma_pml_preserves_larger_base_conductivity():
+def test_absorbing_layer_preserves_larger_base_conductivity():
     fields = _make_fields(base_sigma=0.0)
     design = _make_design()
     fields.conductivity = fields.conductivity.at[3, 4].set(9.0)
-    pml = PML(edges=["left"], thickness=0.2, sigma_max=4.0, formulation="sigma")
+    pml = AbsorbingLayer(edges=["left"], thickness=0.2, sigma_max=4.0)
 
     _attach_pml(fields, pml, design)
     total_sigma = np.asarray(fields.total_conductivity, dtype=np.float64)
@@ -108,3 +108,13 @@ def test_cpml_auxiliary_profiles_do_not_modify_total_conductivity():
         np.asarray(fields.total_conductivity, dtype=np.float64),
         np.asarray(fields.conductivity, dtype=np.float64),
     )
+
+
+def test_sigma_alias_still_builds_absorbing_shell():
+    fields = _make_fields()
+    design = _make_design()
+    pml = PML(edges=["left"], thickness=0.2, sigma_max=6.0, formulation="sigma")
+
+    payload = _attach_pml(fields, pml, design)
+
+    assert payload["formulation"] == "sponge"


### PR DESCRIPTION
Update README and refactor PML boundaries to use 'sponge' formulation. Introduce AbsorbingLayer class for legacy support. Adjust examples and tests to reflect changes in boundary formulations.