### PR TITLE
[Refactor / Mode Solver]: Replace Tidy3D with custom mode solver micromode

### DIFF
--- a/beamz/devices/sources/solve.py
+++ b/beamz/devices/sources/solve.py
@@ -1,95 +1,28 @@
 # Adapted from FDTDx by Yannik Mahlau
 from collections import namedtuple
-from types import SimpleNamespace
-from typing import List, Literal, Tuple, Union
+from typing import Literal, Tuple, Union
 
 import jax
 import jax.numpy as jnp
 import numpy as np
 
-# Lazy import of tidy3d to allow package to work without it
-tidy3d = None
-_compute_modes = None
+# Lazy import of micromode to allow package to work without it
+micromode = None
 
 
-def _ensure_tidy3d():
-    """Lazily import tidy3d when needed."""
-    global tidy3d, _compute_modes
-    if tidy3d is None:
+def _ensure_micromode():
+    """Lazily import micromode when needed."""
+    global micromode
+    if micromode is None:
         try:
-            import tidy3d as _tidy3d
-            from tidy3d.components.mode.solver import compute_modes as _cm
+            import micromode as _micromode
 
-            tidy3d = _tidy3d
-            _compute_modes = _cm
-
-            # Monkey-patch tidy3d derivatives to avoid scipy FutureWarning:
-            # "Input has data type int64, but the output has been cast to float64"
-            _apply_tidy3d_diags_patch()
+            micromode = _micromode
         except ImportError:
             raise ImportError(
-                "tidy3d is required for mode solving. "
-                "Install it with: pip install tidy3d"
+                "micromode is required for mode solving. "
+                "Install it with: pip install micromode"
             )
-
-
-def _apply_tidy3d_diags_patch():
-    """Patch tidy3d's derivatives to use float diagonals in sp.diags (avoids scipy FutureWarning)."""
-    import scipy.sparse as sp
-    import tidy3d.components.mode.derivatives as _deriv
-
-    def _make_dxf(dls, shape, pmc):
-        Nx, Ny = shape
-        if Nx == 1:
-            return sp.csr_matrix((Ny, Ny))
-        dxf = sp.csr_matrix(sp.diags([-1.0, 1.0], [0, 1], shape=(Nx, Nx)))
-        if not pmc:
-            dxf[0, 0] = 0.0
-        dxf = sp.diags(1 / dls).dot(dxf)
-        dxf = sp.kron(dxf, sp.eye(Ny))
-        return dxf
-
-    def _make_dxb(dls, shape, pmc):
-        Nx, Ny = shape
-        if Nx == 1:
-            return sp.csr_matrix((Ny, Ny))
-        dxb = sp.csr_matrix(sp.diags([1.0, -1.0], [0, -1], shape=(Nx, Nx)))
-        if pmc:
-            dxb[0, 0] = 2.0
-        else:
-            dxb[0, 0] = 0.0
-        dxb = sp.diags(1 / dls).dot(dxb)
-        dxb = sp.kron(dxb, sp.eye(Ny))
-        return dxb
-
-    def _make_dyf(dls, shape, pmc):
-        Nx, Ny = shape
-        if Ny == 1:
-            return sp.csr_matrix((Nx, Nx))
-        dyf = sp.csr_matrix(sp.diags([-1.0, 1.0], [0, 1], shape=(Ny, Ny)))
-        if not pmc:
-            dyf[0, 0] = 0.0
-        dyf = sp.diags(1 / dls).dot(dyf)
-        dyf = sp.kron(sp.eye(Nx), dyf)
-        return dyf
-
-    def _make_dyb(dls, shape, pmc):
-        Nx, Ny = shape
-        if Ny == 1:
-            return sp.csr_matrix((Nx, Nx))
-        dyb = sp.csr_matrix(sp.diags([1.0, -1.0], [0, -1], shape=(Ny, Ny)))
-        if pmc:
-            dyb[0, 0] = 2.0
-        else:
-            dyb[0, 0] = 0.0
-        dyb = sp.diags(1 / dls).dot(dyb)
-        dyb = sp.kron(sp.eye(Nx), dyb)
-        return dyb
-
-    _deriv.make_dxf = _make_dxf
-    _deriv.make_dxb = _make_dxb
-    _deriv.make_dyf = _make_dyf
-    _deriv.make_dyb = _make_dyb
 
 
 ModeTupleType = namedtuple("Mode", ["neff", "Ex", "Ey", "Ez", "Hx", "Hy", "Hz"])
@@ -119,6 +52,14 @@ def compute_mode_polarization_fraction(
 
     denominator = np.sum(np.abs(E1) ** 2 + np.abs(E2) ** 2) + 1e-18
     return numerator / denominator
+
+
+def _field_plane(data_array, normal_axis: int, mode_index: int) -> np.ndarray:
+    """Extract a BeamZ transverse field plane from a micromode field component."""
+    normal_dim = ("x", "y", "z")[normal_axis]
+    selected = data_array.isel(f=0, mode_index=mode_index)
+    normal_position = selected.dims.index(normal_dim)
+    return np.take(np.asarray(selected.values), indices=0, axis=normal_position)
 
 
 def sort_modes(
@@ -156,7 +97,7 @@ def compute_mode(
     filter_pol: Union[Literal["te", "tm"], None] = None,
     target_neff: Union[float, None] = None,
 ) -> tuple[np.ndarray, np.ndarray, complex, int]:
-    _ensure_tidy3d()  # Lazy import tidy3d
+    _ensure_micromode()  # Lazy import micromode
     inv_permittivities = np.asarray(inv_permittivities, dtype=np.complex128)
     if inv_permittivities.ndim == 1:
         inv_permittivities = inv_permittivities[np.newaxis, :, np.newaxis]
@@ -192,6 +133,7 @@ def compute_mode(
     cross_axes = [ax for ax in range(inv_permittivities.ndim) if ax != propagation_axis]
     if not cross_axes:
         raise ValueError("Need at least one transverse axis for mode computation")
+    is_1d_profile = len(singleton_axes) >= 2
 
     permittivities = 1 / inv_permittivities
     coords = [
@@ -210,22 +152,35 @@ def compute_mode(
     else:
         permeability_squeezed = 1 / inv_permeabilities.item()
 
-    # The mode solver returns fields in a local basis where the first two E
-    # components correspond to the tangential pair used for TE/TM filtering.
-    # Keep TE/TM ranking consistent with the global conventions used by
-    # ModeSource setup (e.g. +x: TE~Ey/Hz, TM~Ez/Hy).
-    tangential_axes_map = {0: (0, 1), 1: (0, 1), 2: (0, 1)}
+    if np.ndim(permeability_squeezed) == 0:
+        mu_xx = np.full_like(permittivity_squeezed, permeability_squeezed)
+    else:
+        mu_xx = np.asarray(permeability_squeezed, dtype=np.complex128)
 
-    modes = tidy3d_mode_computation_wrapper(
-        frequency=frequency,
-        permittivity_cross_section=permittivity_squeezed,
-        permeability_cross_section=permeability_squeezed,
-        coords=coords,
+    result = micromode.solve_grid(
+        eps_xx=permittivity_squeezed,
+        mu_xx=mu_xx,
+        x_edges=coords[0],
+        y_edges=coords[1],
+        freqs=[frequency],
         direction=direction,
         num_modes=2 * (mode_index + 1) + 5,
         target_neff=target_neff,
+        normal_axis=propagation_axis,
     )
-    tangential_axes = tangential_axes_map.get(propagation_axis, (0, 1))
+    modes = [
+        ModeTupleType(
+            neff=result.n_complex.values[0, idx],
+            Ex=_field_plane(result.field_components["Ex"], propagation_axis, idx),
+            Ey=_field_plane(result.field_components["Ey"], propagation_axis, idx),
+            Ez=_field_plane(result.field_components["Ez"], propagation_axis, idx),
+            Hx=_field_plane(result.field_components["Hx"], propagation_axis, idx),
+            Hy=_field_plane(result.field_components["Hy"], propagation_axis, idx),
+            Hz=_field_plane(result.field_components["Hz"], propagation_axis, idx),
+        )
+        for idx in range(result.n_complex.shape[1])
+    ]
+    tangential_axes = tuple(ax for ax in range(3) if ax != propagation_axis)
     modes = sort_modes(modes, filter_pol, tangential_axes)
     if mode_index >= len(modes):
         raise ValueError(
@@ -234,15 +189,13 @@ def compute_mode(
 
     mode = modes[mode_index]
 
-    if propagation_axis == 0:
-        E = np.stack([mode.Ez, mode.Ex, mode.Ey], axis=0).astype(np.complex128)
-        H = np.stack([mode.Hz, mode.Hx, mode.Hy], axis=0).astype(np.complex128)
-    elif propagation_axis == 1:
-        E = np.stack([mode.Ex, mode.Ez, mode.Ey], axis=0).astype(np.complex128)
-        H = -np.stack([mode.Hx, mode.Hz, mode.Hy], axis=0).astype(np.complex128)
-    else:
-        E = np.stack([mode.Ex, mode.Ey, mode.Ez], axis=0).astype(np.complex128)
-        H = np.stack([mode.Hx, mode.Hy, mode.Hz], axis=0).astype(np.complex128)
+    E = np.stack([mode.Ex, mode.Ey, mode.Ez], axis=0).astype(np.complex128)
+    H = np.stack([mode.Hx, mode.Hy, mode.Hz], axis=0).astype(np.complex128)
+    if propagation_axis == 1:
+        H = -H
+    if is_1d_profile:
+        E = E[..., 0]
+        H = H[..., 0]
 
     E_norm, H_norm = _normalize_by_poynting_flux(E, H, axis=propagation_axis)
     return E_norm, H_norm, np.asarray(mode.neff, dtype=np.complex128), propagation_axis
@@ -343,69 +296,6 @@ def solve_modes(
     return neff_array, np.column_stack(mode_vectors)
 
 
-def tidy3d_mode_computation_wrapper(
-    frequency: float,
-    permittivity_cross_section: np.ndarray,
-    coords: List[np.ndarray],
-    direction: Literal["+", "-"],
-    permeability_cross_section: Union[np.ndarray, None] = None,
-    target_neff: Union[float, None] = None,
-    angle_theta: float = 0.0,
-    angle_phi: float = 0.0,
-    num_modes: int = 10,
-    precision: Literal["single", "double"] = "double",
-) -> List[ModeTupleType]:
-    _ensure_tidy3d()  # Lazy import tidy3d
-    mode_spec = SimpleNamespace(
-        num_modes=num_modes,
-        target_neff=target_neff,
-        num_pml=(0, 0),
-        angle_theta=angle_theta,
-        angle_phi=angle_phi,
-        bend_radius=None,
-        bend_axis=None,
-        precision=precision,
-        track_freq="central",
-        group_index_step=False,
-    )
-    od = np.zeros_like(permittivity_cross_section)
-    eps_cross = [permittivity_cross_section if i in {0, 4, 8} else od for i in range(9)]
-    mu_cross = None
-    if permeability_cross_section is not None:
-        mu_cross = [
-            permeability_cross_section if i in {0, 4, 8} else od for i in range(9)
-        ]
-
-    EH, neffs, _ = _compute_modes(
-        eps_cross=eps_cross,
-        coords=coords,
-        freq=frequency,
-        precision=precision,
-        mode_spec=mode_spec,
-        direction=direction,
-        mu_cross=mu_cross,
-    )
-    (Ex, Ey, Ez), (Hx, Hy, Hz) = EH.squeeze()
-
-    if num_modes == 1:
-        return [
-            ModeTupleType(Ex=Ex, Ey=Ey, Ez=Ez, Hx=Hx, Hy=Hy, Hz=Hz, neff=complex(neffs))
-        ]
-
-    return [
-        ModeTupleType(
-            Ex=Ex[..., i],
-            Ey=Ey[..., i],
-            Ez=Ez[..., i],
-            Hx=Hx[..., i],
-            Hy=Hy[..., i],
-            Hz=Hz[..., i],
-            neff=neffs[i],
-        )
-        for i in range(min(num_modes, Ex.shape[-1]))
-    ]
-
-
 def _normalize_by_poynting_flux(
     E: np.ndarray, H: np.ndarray, axis: int
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -450,7 +340,7 @@ def solve_modes_differentiable(
 ) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
     """JAX-compatible wrapper for mode solving with custom gradients.
 
-    This function wraps the tidy3d-based mode solver to enable gradient computation
+    This function wraps the micromode-based mode solver to enable gradient computation
     via finite differences. The forward pass calls the numpy-based solve_modes,
     and the backward pass computes gradients for omega (wavelength) using finite differences.
 
@@ -465,7 +355,7 @@ def solve_modes_differentiable(
     Returns:
         Tuple of (neff_array, E_fields, H_fields) as JAX arrays
     """
-    # Convert JAX array to numpy for tidy3d
+    # Convert JAX array to numpy for micromode
     eps_np = np.asarray(eps)
 
     # Call the numpy-based solver
@@ -499,7 +389,7 @@ def solve_modes_jax(
 
     This function enables gradient computation through the mode solver
     with respect to omega (and thus wavelength). Uses finite differences
-    for the backward pass since tidy3d is not JAX-compatible.
+    for the backward pass since micromode is not JAX-compatible.
 
     Args:
         omega: Angular frequency (differentiable parameter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "gdsfactory",
     "jaxlib>=0.4.0",
     "optax>=0.1.0",
-    "tidy3d>=2.0.0",
+    "micromode>=0.1.0a1",
     "traitlets>=5.14.0",
     "matplotlib>=3.8.0",
     "scikit-image>=0.21.0",

--- a/uv.lock
+++ b/uv.lock
@@ -95,19 +95,6 @@ wheels = [
 ]
 
 [[package]]
-name = "autograd"
-version = "1.8.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/67/1c/3c24ec03c8ba4decc742b1df5a10c52f98c84ca8797757f313e7bdcdf276/autograd-1.8.0.tar.gz", hash = "sha256:107374ded5b09fc8643ac925348c0369e7b0e73bbed9565ffd61b8fd04425683", size = 2562146, upload-time = "2025-05-05T12:49:02.502Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/ea/e16f0c423f7d83cf8b79cae9452040fb7b2e020c7439a167ee7c317de448/autograd-1.8.0-py3-none-any.whl", hash = "sha256:4ab9084294f814cf56c280adbe19612546a35574d67c574b04933c7d2ecb7d78", size = 51478, upload-time = "2025-05-05T12:49:00.585Z" },
-]
-
-[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -144,6 +131,7 @@ dependencies = [
     { name = "jaxlib", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "jaxlib", version = "0.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "matplotlib" },
+    { name = "micromode" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "optax" },
@@ -153,7 +141,6 @@ dependencies = [
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "shapely" },
-    { name = "tidy3d" },
     { name = "traitlets" },
 ]
 
@@ -189,6 +176,7 @@ requires-dist = [
     { name = "jax", specifier = ">=0.4.0" },
     { name = "jaxlib", specifier = ">=0.4.0" },
     { name = "matplotlib", specifier = ">=3.8.0" },
+    { name = "micromode", specifier = ">=0.1.0a1" },
     { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.0.0" },
     { name = "myst-parser", marker = "extra == 'dev'", specifier = ">=2.0.0" },
@@ -203,7 +191,6 @@ requires-dist = [
     { name = "scikit-image", specifier = ">=0.21.0" },
     { name = "scipy", specifier = ">=1.10.1" },
     { name = "shapely", specifier = ">=2.0.6" },
-    { name = "tidy3d", specifier = ">=2.0.0" },
     { name = "torch", marker = "extra == 'gpu'", specifier = ">=2.6.0" },
     { name = "traitlets", specifier = ">=5.14.0" },
 ]
@@ -251,34 +238,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/9c/cd3deb79bfec5bcf30f9d2100ffeec63eecce826eb63e3961708b9431ff1/black-26.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:f016baaadc423dc960cdddf9acae679e71ee02c4c341f78f3179d7e4819c095f", size = 1433217, upload-time = "2026-01-18T04:59:52.218Z" },
     { url = "https://files.pythonhosted.org/packages/4e/29/f3be41a1cf502a283506f40f5d27203249d181f7a1a2abce1c6ce188035a/black-26.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:66912475200b67ef5a0ab665011964bf924745103f51977a78b4fb92a9fc1bf0", size = 1245773, upload-time = "2026-01-18T04:59:54.457Z" },
     { url = "https://files.pythonhosted.org/packages/e4/3d/51bdb3ecbfadfaf825ec0c75e1de6077422b4afa2091c6c9ba34fbfc0c2d/black-26.1.0-py3-none-any.whl", hash = "sha256:1054e8e47ebd686e078c0bb0eaf31e6ce69c966058d122f2c0c950311f9f3ede", size = 204010, upload-time = "2026-01-18T04:50:09.978Z" },
-]
-
-[[package]]
-name = "boto3"
-version = "1.42.35"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-    { name = "jmespath" },
-    { name = "s3transfer" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/a4/e70cc79e8f91836c06021c35507c843e5bc39a2020a85a6a27a492b50f78/boto3-1.42.35.tar.gz", hash = "sha256:edbfbfbadd419e65888166dd044786d4b731cf60abeb2301b73e775e154d7c5e", size = 112928, upload-time = "2026-01-26T20:35:37.524Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/26/75b6301514c74c398207462086af6cfe2a875fd8700a6e508559bb1ed21a/boto3-1.42.35-py3-none-any.whl", hash = "sha256:4251bbac90e4a190680439973d9e9ed851e50292c10cd063c8bf0c365410ffe1", size = 140606, upload-time = "2026-01-26T20:35:35.398Z" },
-]
-
-[[package]]
-name = "botocore"
-version = "1.42.35"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jmespath" },
-    { name = "python-dateutil" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/3d/339edff36a3c6617900ec9d7a1203ffe4e06ffee1e5bd71126e31cd59e30/botocore-1.42.35.tar.gz", hash = "sha256:40a6e0f16afe9e5d42e956f0b6d909869793fadb21780e409063601fc3d094b8", size = 14903745, upload-time = "2026-01-26T20:35:25.85Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/74/b6/68f0aec79462852f367128dd8892e47176da46a787386d1730ec5bbbfb01/botocore-1.42.35-py3-none-any.whl", hash = "sha256:b89f527987691abbd1374c4116cc2711471ce48e6da502db17e92b17b2af8d47", size = 14581567, upload-time = "2026-01-26T20:35:23.346Z" },
 ]
 
 [[package]]
@@ -522,15 +481,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
-]
-
-[[package]]
-name = "cloudpickle"
-version = "3.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
 ]
 
 [[package]]
@@ -844,25 +794,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
-]
-
-[[package]]
-name = "dask"
-version = "2025.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "cloudpickle" },
-    { name = "fsspec" },
-    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
-    { name = "packaging" },
-    { name = "partd" },
-    { name = "pyyaml" },
-    { name = "toolz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/ae/92fca08ff8fe3e8413842564dd55ee30c9cd9e07629e1bf4d347b005a5bf/dask-2025.12.0.tar.gz", hash = "sha256:8d478f2aabd025e2453cf733ad64559de90cf328c20209e4574e9543707c3e1b", size = 10995316, upload-time = "2025-12-12T14:59:10.885Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/3a/2121294941227c548d4b5f897a8a1b5f4c44a58f5437f239e6b86511d78e/dask-2025.12.0-py3-none-any.whl", hash = "sha256:4213ce9c5d51d6d89337cff69de35d902aa0bf6abdb8a25c942a4d0281f3a598", size = 1481293, upload-time = "2025-12-12T14:58:59.32Z" },
 ]
 
 [[package]]
@@ -1201,19 +1132,6 @@ wheels = [
 ]
 
 [[package]]
-name = "h5netcdf"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h5py" },
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/3c/71308369d52c5ab3395793a8e19220ee7586549ccd6b4ffca15b1a20a9bc/h5netcdf-1.0.2.tar.gz", hash = "sha256:8808a1e095f0122b4fb408cc98c60adf399bd57fef48d1ca7cdf4cda1d0a6b4a", size = 53421, upload-time = "2022-08-02T09:34:13.284Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/81/569ab60d33e51482192a278ee3457704805470d8fe0d757237cf02f01c53/h5netcdf-1.0.2-py2.py3-none-any.whl", hash = "sha256:4a4c277e18a906ab66e78ae2d95d27de4eec3519b87871adfd137974265bc250", size = 24711, upload-time = "2022-08-02T09:34:11.812Z" },
-]
-
-[[package]]
 name = "h5py"
 version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1275,18 +1193,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a", size = 1280026, upload-time = "2022-07-01T12:21:05.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b", size = 8769, upload-time = "2022-07-01T12:21:02.467Z" },
-]
-
-[[package]]
-name = "importlib-metadata"
-version = "8.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
 ]
 
 [[package]]
@@ -1574,24 +1480,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jmespath"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
-]
-
-[[package]]
-name = "joblib"
-version = "1.5.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
-]
-
-[[package]]
 name = "jupyter-client"
 version = "8.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1872,15 +1760,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6b/c875b30a1ba490860c93da4cabf479e03f584eba06fe5963f6f6644653d8/lazy_loader-0.4.tar.gz", hash = "sha256:47c75182589b91a4e1a85a136c074285a5ad4d9f39c63e0d7fb76391c4574cd1", size = 15431, upload-time = "2024-04-05T13:03:12.261Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/60/d497a310bde3f01cb805196ac61b7ad6dc5dcf8dce66634dc34364b20b4f/lazy_loader-0.4-py3-none-any.whl", hash = "sha256:342aa8e14d543a154047afb4ba8ef17f5563baad3fc610d7b15b213b0f119efc", size = 12097, upload-time = "2024-04-05T13:03:10.514Z" },
-]
-
-[[package]]
-name = "locket"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/83/97b29fe05cb6ae28d2dbd30b81e2e402a3eed5f460c26e9eaa5895ceacf5/locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632", size = 4350, upload-time = "2022-04-20T22:04:44.312Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3", size = 4398, upload-time = "2022-04-20T22:04:42.23Z" },
 ]
 
 [[package]]
@@ -2211,6 +2090,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "micromode"
+version = "0.1.0a1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h5py" },
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "xarray", version = "2025.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "xarray", version = "2025.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/8e/45b821b2f60beeb6250b7f7b78eb505e568dee7ff3be3a24601d1824f25e/micromode-0.1.0a1.tar.gz", hash = "sha256:e163cb052091bfee5484bcb2c36a90c5bc6ed310c3dbd43cf41f49995d1c2348", size = 10725221, upload-time = "2026-05-16T15:27:18.16Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/3d/9e83e0bd02e3666d702828c483615b532922c5c5c39d606031923e55349f/micromode-0.1.0a1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:5a2699c03eda84d627ebb8c0a9a8614f9e5d3c4578a797cfd1062bf6e5ec1af0", size = 23810274, upload-time = "2026-05-16T15:26:39.483Z" },
+    { url = "https://files.pythonhosted.org/packages/86/de/7b657df70fc28bc0274db2d7cad9c690c13e763b58ec293484fffb07018b/micromode-0.1.0a1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b8227af97565ac1663a5e8a67b6a7f6f43d98d07c41b1c989177695fda9318ec", size = 20370775, upload-time = "2026-05-16T15:26:42.45Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/db/2de74ca8c4cbf592b8105953fdb5c7b89aca12f05b50821beefff758c820/micromode-0.1.0a1-cp310-cp310-manylinux_2_38_x86_64.whl", hash = "sha256:3f801405fca20b995e0c3120282f789c4e590620ae97f261e6ee04f3b3aaee17", size = 17930110, upload-time = "2026-05-16T15:26:45.039Z" },
+    { url = "https://files.pythonhosted.org/packages/38/db/400ada0466c6443224da66267d6bd5dce25d2515f6d9f070bb36f8bfb419/micromode-0.1.0a1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:043ede028f392cd8265605bc78c50ce3e4dd663b1c4499afeb5063f6b1003e92", size = 23810381, upload-time = "2026-05-16T15:26:48.572Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/ab/f1bd5d21425b53dcc8834a20909469388646b39630a5f97f9ce72c4ae950/micromode-0.1.0a1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ce2222d533bbf4c3f0a4134ba6c6aefd6077de03047ca85e2e7dd2683d185121", size = 20370776, upload-time = "2026-05-16T15:26:51.652Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5f/b8209604a6805a887d21b9122a62fe850b01926eb55976bf5e4297b1a153/micromode-0.1.0a1-cp311-cp311-manylinux_2_38_x86_64.whl", hash = "sha256:23f37b15c8037a019f02d2adaf08d9619464dc2d9a396b03a69a2652036319f9", size = 17929906, upload-time = "2026-05-16T15:26:54.35Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/4e/b7237baca27be1ce532c1e2a1f6363f9d14024cddab9d2b1df60e2823932/micromode-0.1.0a1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:644ceaa111c12f372b45deb7cfe02a8423206797e2072de465897033f97fbd8d", size = 23807727, upload-time = "2026-05-16T15:26:57.957Z" },
+    { url = "https://files.pythonhosted.org/packages/41/1a/c90a96af21caa1f1e4abb8f20992f8186463af8badc14a7d9400af6e7cb6/micromode-0.1.0a1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0ec3b072864135caedc83417edd1f90cd49da928fa6ba0662c96130ddde72f87", size = 20367191, upload-time = "2026-05-16T15:27:01.483Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/78/e0dec67c1138663a7a4672379e41296af2329bf46dbfe2f106f058852ea2/micromode-0.1.0a1-cp312-cp312-manylinux_2_38_x86_64.whl", hash = "sha256:fa05d6ab6f7e549ba2e8a84ff5d4617eb507a02c2cd7f8dd2e62eee217e200e6", size = 17928867, upload-time = "2026-05-16T15:27:04.486Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/29/c32f763df520474f37d40d24ffe2320ebb1110c6e5ecc6e83ac76e4999e2/micromode-0.1.0a1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5dabcee30a2bb46b0ee20cb1288cd3b5a57a5646268a1c6b68da5b286d4d030e", size = 23807272, upload-time = "2026-05-16T15:27:07.328Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ae/e2fbef16f81d65865550b96ed527c314e4652cf7aa019071cfec05581d57/micromode-0.1.0a1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f52a055c2569f0416b0e3eef90a510ecde70238fe99111dcb1d3897d3fdcc8a5", size = 20366774, upload-time = "2026-05-16T15:27:11.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c9/e35d55d6eecbd03799d2f1dca127539988eb357fab71e664b06658246f48/micromode-0.1.0a1-cp313-cp313-manylinux_2_38_x86_64.whl", hash = "sha256:fd08893f076695b1a30be3d43bed4bdecea965f0fe12b383dbb9c8549cb68997", size = 17928790, upload-time = "2026-05-16T15:27:15.147Z" },
 ]
 
 [[package]]
@@ -2916,19 +2823,6 @@ wheels = [
 ]
 
 [[package]]
-name = "partd"
-version = "1.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "locket" },
-    { name = "toolz" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/3a/3f06f34820a31257ddcabdfafc2672c5816be79c7e353b02c1f318daa7d4/partd-1.4.2.tar.gz", hash = "sha256:d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c", size = 21029, upload-time = "2024-05-06T19:51:41.945Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl", hash = "sha256:978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f", size = 18905, upload-time = "2024-05-06T19:51:39.271Z" },
-]
-
-[[package]]
 name = "pathspec"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3536,15 +3430,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyjwt"
-version = "2.10.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
-]
-
-[[package]]
 name = "pymdown-extensions"
 version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3564,15 +3449,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
-]
-
-[[package]]
-name = "pyroots"
-version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c6/f0/b08fb6588d1f39af384910eca3029a10d0df73a6fa81f4106e172e4e9274/pyroots-0.5.0.tar.gz", hash = "sha256:76f3c55c20d8c2a88e1baaef912854206a0dd8fbcc2715ee6ed0a646860c2cf0", size = 14002, upload-time = "2020-06-17T13:14:55.77Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/36/887abb4891f67ea0cf458f4af80f7aba29fd7df2d2723373a493a3a7152c/pyroots-0.5.0-py2.py3-none-any.whl", hash = "sha256:830cf8248ee9d4ded2d2da94137f84ff5112b399d2bcf2a48e824e2213a5769f", size = 17977, upload-time = "2020-06-17T13:14:54.187Z" },
 ]
 
 [[package]]
@@ -4001,20 +3877,6 @@ wheels = [
 ]
 
 [[package]]
-name = "responses"
-version = "0.25.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/95/89c054ad70bfef6da605338b009b2e283485835351a9935c7bfbfaca7ffc/responses-0.25.8.tar.gz", hash = "sha256:9374d047a575c8f781b94454db5cab590b6029505f488d12899ddb10a4af1cf4", size = 79320, upload-time = "2025-08-08T19:01:46.709Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/4c/cc276ce57e572c102d9542d383b2cfd551276581dc60004cb94fe8774c11/responses-0.25.8-py3-none-any.whl", hash = "sha256:0c710af92def29c8352ceadff0c3fe340ace27cf5af1bbe46fb71275bcd2831c", size = 34769, upload-time = "2025-08-08T19:01:45.018Z" },
-]
-
-[[package]]
 name = "rich"
 version = "13.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4057,18 +3919,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/11/47/fa7c06b8f9946fc9192cb4d944367f31197715915f5e71363909e8c35eb7/ruamel.yaml.string-0.1.1.tar.gz", hash = "sha256:7a7aedcc055d45c004d38b756f58474ebefb106851f4ce56ce58415709784350", size = 12678, upload-time = "2023-05-02T05:37:18.085Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/91/2a/b508237a7fcceab8a8724405480eb55d527523419c9dbcde369f954656ad/ruamel.yaml.string-0.1.1-py3-none-any.whl", hash = "sha256:eb146bcb42b116216638034a434e9cf3ae2a5d3933aa37183a9854b5f3ff42de", size = 4118, upload-time = "2023-05-02T05:37:20.332Z" },
-]
-
-[[package]]
-name = "s3transfer"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "botocore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]
@@ -4616,45 +4466,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tidy3d"
-version = "2.10.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "autograd" },
-    { name = "boto3" },
-    { name = "click" },
-    { name = "dask" },
-    { name = "h5netcdf" },
-    { name = "h5py" },
-    { name = "importlib-metadata" },
-    { name = "joblib" },
-    { name = "matplotlib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pandas" },
-    { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pyjwt" },
-    { name = "pyroots" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "responses" },
-    { name = "rich" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "shapely" },
-    { name = "toml" },
-    { name = "tomlkit" },
-    { name = "typing-extensions" },
-    { name = "xarray", version = "2025.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "xarray", version = "2025.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/8d/b27cf95b84d433ee4e4f6a4e929c4fd6350f1b3711e2138db065f1ce3a96/tidy3d-2.10.2.tar.gz", hash = "sha256:8ff4494d6328113829e0c931135e7c46312fcd814c3d461b404f99bbeb57f4c7", size = 1223385, upload-time = "2026-01-26T15:46:46.489Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/1c/09573cfaa87ca65745f499888853de443c332f0a1d2104ef70dbad993d3c/tidy3d-2.10.2-py3-none-any.whl", hash = "sha256:a390e7f1b96e9d0b838b6a223913e47b36a50c17f6b96a755acf237913ff48cc", size = 1399277, upload-time = "2026-01-26T15:46:44.674Z" },
-]
-
-[[package]]
 name = "tifffile"
 version = "2025.5.10"
 source = { registry = "https://pypi.org/simple" }
@@ -4684,15 +4495,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/df/de4a076ca4201f92f04aa07d348c734b223e78f763061a18b607bc9b9746/tifffile-2026.2.16.tar.gz", hash = "sha256:9d509a9121431c7228c1f6f71736a73af155bdeb60c324ab09c9eb2e83cfc4b6", size = 375841, upload-time = "2026-02-17T00:59:15.717Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/06/a8e97165d82f866a40117f213d2f8a32f297c9c76ec9c16a1a2c680e0f59/tifffile-2026.2.16-py3-none-any.whl", hash = "sha256:ea76cb4d8aa290f7f164840dfe4e244d104bd90c84d5ee1e6de6d84fd4745a48", size = 233550, upload-time = "2026-02-17T00:59:13.729Z" },
-]
-
-[[package]]
-name = "toml"
-version = "0.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
 ]
 
 [[package]]
@@ -4747,15 +4549,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
-]
-
-[[package]]
-name = "tomlkit"
-version = "0.13.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cc/18/0bbf3884e9eaa38819ebe46a7bd25dcd56b67434402b66a58c4b8e552575/tomlkit-0.13.3.tar.gz", hash = "sha256:430cf247ee57df2b94ee3fbe588e71d362a941ebb545dec29b53961d61add2a1", size = 185207, upload-time = "2025-06-05T07:13:44.947Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/75/8539d011f6be8e29f339c42e633aae3cb73bffa95dd0f9adec09b9c58e85/tomlkit-0.13.3-py3-none-any.whl", hash = "sha256:c89c649d79ee40629a9fda55f8ace8c6a1b42deb912b2a8fd8d942ddadb606b0", size = 38901, upload-time = "2025-06-05T07:13:43.546Z" },
 ]
 
 [[package]]
@@ -5051,13 +4844,4 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d3/af/7b945f331ba8911fdfff2fdfa092763156119f124be1ba4144615c540222/xarray-2025.12.0.tar.gz", hash = "sha256:73f6a6fadccc69c4d45bdd70821a47c72de078a8a0313ff8b1e97cd54ac59fed", size = 3082244, upload-time = "2025-12-05T21:51:22.432Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/e4/62a677feefde05b12a70a4fc9bdc8558010182a801fbcab68cb56c2b0986/xarray-2025.12.0-py3-none-any.whl", hash = "sha256:9e77e820474dbbe4c6c2954d0da6342aa484e33adaa96ab916b15a786181e970", size = 1381742, upload-time = "2025-12-05T21:51:20.841Z" },
-]
-
-[[package]]
-name = "zipp"
-version = "3.23.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
Replace tidy3d with micromode for mode solving in solve.py; update dependencies in pyproject.toml and uv.lock to reflect this change.