### PR TITLE
[Fix]: Resolve 3D source phase-referenced power tests

### DIFF
--- a/tests/test_3d_constitutive_sampling.py
+++ b/tests/test_3d_constitutive_sampling.py
@@ -770,14 +770,13 @@ def _source_phase_referenced_power(
         k_num=float(source._k_num_axis),
         ref_coord=float(source._phase_ref_coord),
     )
-    return float(
-        _modal_power_3d_from_profiles(
-            referenced,
-            axis=axis,
-            d_area=d_area,
-            direction_sign=float(source._direction_sign),
-        )
+    signed_power = _modal_power_3d_from_profiles(
+        referenced,
+        axis=axis,
+        d_area=d_area,
+        direction_sign=float(source._direction_sign),
     )
+    return float(abs(signed_power))
 
 
 def _max_complex_part(deltas: dict[str, np.ndarray]) -> tuple[float, float]:


### PR DESCRIPTION
## Summary

- compares 3D source launched power using the same magnitude-based phase-referenced flux convention as production normalization
- keeps raw-basis branch purity checks for the deembedded phasor/profile comparison

## Validation

- uv run pytest tests/test_3d_constitutive_sampling.py::test_source_plane_full_incident_phasor_matches_runtime_profile_basis tests/test_3d_constitutive_sampling.py::test_source_plane_three_way_projection_localizes_rejected_branch_to_yee_update -q
- uv run pytest tests/test_3d_constitutive_sampling.py -q