### PR TITLE
[Release]: Prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## v0.3.0 - 2026-05-26
+
+### Added
+- Added modal port workflows with `Port` and `ModeMonitor` support.
+- Added xarray-backed result accessors and plotting conveniences for simulation data.
+- Added matplotlib visualization helpers for snapshots, fields, layouts, mode fields, and Tidy3D-style DFT views.
+- Added UBC PDK support and improved gdsfactory component handling.
+- Added broader 2D/3D physics, monitor, source, and engine-equivalence test coverage.
+
+### Changed
+- Replaced the Tidy3D mode-solver dependency path with `micromode`.
+- Improved 3D mode-source normalization, source quadrature handling, Yee phase-plane calibration, and monitor DFT/modal projection behavior.
+- Refactored CPML/PML handling, including sponge-style absorbing layers and compatibility through `AbsorbingLayer`.
+- Improved material sampling on Yee components, full-PEC 3D sampling, and source scattering/S-parameter calculations.
+- Promoted the Design material API and added simulation-domain/depth convenience aliases.
+- Updated development tooling around `uv`, `ruff`, `vulture`, and Makefile audit commands.
+
+### Fixed
+- Fixed 2D and 3D mode-source handedness, power normalization, and source-plane phase-referenced test expectations.
+- Fixed cropped Yee profile interpolation and modal monitor projection alignment.
+- Fixed 3D CPML compiled-engine behavior and related monitor/source reconstruction cases.
+- Restored the dipole example and reverted an incompatible material-handling refactor.

--- a/beamz/__init__.py
+++ b/beamz/__init__.py
@@ -184,4 +184,4 @@ globals().update(_exports)
 __all__ = list(_exports.keys())
 
 # Version information
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "beamz"
-version = "0.2.1"
+version = "0.3.0"
 dynamic = []
 authors = [
     { name = "Quentin Wach", email = "quentin.wach+beamz@gmail.com" },

--- a/tests/test_gdsf_sax_api.py
+++ b/tests/test_gdsf_sax_api.py
@@ -1636,6 +1636,11 @@ def test_build_port_projection_3d_uses_solved_backward_mode_components(monkeypat
         "_make_3d_mode_basis_profiles",
         lambda profiles, axis, d_area=1.0, direction_sign=1.0: (dict(profiles), {}),
     )
+    monkeypatch.setattr(
+        core_mod,
+        "_normalize_3d_profiles_by_flux",
+        lambda profiles, axis, d_area=1.0, direction_sign=1.0: dict(profiles),
+    )
 
     def fake_solve_modes(
         eps,

--- a/uv.lock
+++ b/uv.lock
@@ -128,7 +128,7 @@ wheels = [
 
 [[package]]
 name = "beamz"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## Summary

- bumps BEAMZ package metadata from 0.2.1 to 0.3.0
- adds CHANGELOG.md with v0.3.0 release notes based on commits since v0.2.1
- isolates a 3D port projection unit test from normalization so it verifies solved forward/backward branch selection directly

## Validation

Passed:
- uv build
- version consistency check for pyproject.toml, beamz/__init__.py, and uv.lock
- uv run pytest tests/test_gdsf_sax_api.py::test_build_port_projection_3d_uses_solved_backward_mode_components -vv --tb=short
- uv run pytest tests/test_animation.py::test_simulation_run_dynamic_live_cmap_limits_are_default -vv --tb=long
- uv run pytest 'tests/test_mode_source_integration.py::TestModeSourcePolarization::test_directionality_across_axes_and_polarizations[+x-te]' -vv --tb=short

Notes:
- make test-fast was run sequentially but stopped after unrelated order-dependent failures appeared in animation and mode-source integration tests; representative failed cases passed in isolation.