### PR TITLE
[Optimization]: Add Hammond subpixel-smoothed projection

### DIFF
--- a/beamz/optimization/README.md
+++ b/beamz/optimization/README.md
@@ -28,8 +28,14 @@ A library of JAX-based differentiable operations used for density filtering and 
   - `masked_box_blur`: Standard box blur implementation.
 - **Projection**:
   - `smoothed_heaviside`: A differentiable step function (using `tanh`) to binarize the density field.
+  - `transform_density`: Applies the selected filter and projection method.
 - **Backpropagation**:
   - `compute_parameter_gradient_vjp`: Uses JAX's vector-Jacobian product (VJP) to automatically compute gradients through the entire filter-project pipeline.
+
+### `projections.py`
+Projection methods for filtered topology-optimization densities.
+- `smoothed_heaviside`: The default tanh-based projection method.
+- `subpixel_smoothed_projection`: Hammond SSP1 for smooth 2D density fields.
 
 ## Key Features
 
@@ -37,7 +43,43 @@ A library of JAX-based differentiable operations used for density filtering and 
 2.  **Geometric Constraints**: The **conic filter** option provides a method to enforce minimum length scales (linewidth and spacing) by using a cone-shaped kernel, as described in topology optimization literature.
 3.  **Connectivity Preservation**: The filtering pipeline includes a mechanism to "pad" the design region with information from fixed structures (like input/output waveguides). This prevents the optimization from creating gaps or disconnecting the device from the external circuit.
 4.  **Beta-Continuation**: Supports a beta-schedule for the Heaviside projection, gradually increasing the sharpness of the binarization to avoid getting stuck in local minima while ensuring a final binary design.
-5.  **JAX Integration**: All heavy lifting for density transformation and gradient chain-rule calculation is handled efficiently by JAX. Uses `optax` for JAX-native optimizer implementations (Adam, SGD).
+5.  **Projection Selection**: Supports `projection_type="heaviside"` for the default tanh projection and `projection_type="ssp"` for Hammond subpixel-smoothed projection.
+6.  **JAX Integration**: All heavy lifting for density transformation and gradient chain-rule calculation is handled efficiently by JAX. Uses `optax` for JAX-native optimizer implementations (Adam, SGD).
+
+## Projection Methods
+
+The density transform follows:
+
+```text
+design density -> filter -> projection -> physical density
+```
+
+Available projection methods:
+
+- `projection_type="heaviside"`: the default tanh smoothed Heaviside projection.
+- `projection_type="ssp"`: Hammond SSP1, applied to the already-filtered 2D density field.
+
+SSP is intended for smooth or filtered 2D density inputs. It supports `beta=jnp.inf`
+without adding any runtime, optional, or test dependency. The smoothing radius is in
+density-grid cell units and defaults to `ssp_smoothing_radius=0.55`.
+
+Example:
+
+```python
+import jax.numpy as jnp
+
+from beamz.optimization.autodiff import transform_density
+
+physical_density = transform_density(
+    density,
+    mask,
+    beta=jnp.inf,
+    eta=0.5,
+    radius=2,
+    filter_type="conic",
+    projection_type="ssp",
+)
+```
 
 ## Usage Example
 
@@ -52,9 +94,10 @@ opt = TopologyManager(
     design=design,
     region_mask=mask,
     resolution=DX,
-    filter_type='conic', # Options: 'morphological', 'conic', 'blur'
+    filter_type='conic', # Options: 'morphological', 'conic'
+    projection_type='ssp',
     filter_radius=0.15*µm,       # Physical units (e.g. microns)
-    simple_smooth_radius=0.03*µm # Optional smoothing (physical units)
+    ssp_smoothing_radius=0.55    # Density-grid cell units
 )
 
 # 3. Optimization Loop

--- a/beamz/optimization/__init__.py
+++ b/beamz/optimization/__init__.py
@@ -6,10 +6,13 @@ from .polygonize import (
     density_to_shapely_geometry,
     shapely_geometry_to_polygons,
 )
+from .projections import smoothed_heaviside, subpixel_smoothed_projection
 
 __all__ = [
     "topology",
     "adjoint_memmap",
+    "smoothed_heaviside",
+    "subpixel_smoothed_projection",
     "density_to_shapely_geometry",
     "shapely_geometry_to_polygons",
     "density_to_polygons",

--- a/beamz/optimization/autodiff.py
+++ b/beamz/optimization/autodiff.py
@@ -6,6 +6,8 @@ import jax
 import jax.numpy as jnp
 from jax.scipy.signal import convolve2d
 
+from .projections import project_density, smoothed_heaviside  # noqa: F401
+
 
 @partial(jax.jit, static_argnames=["radius"])
 def generate_conic_kernel(radius: int):
@@ -65,18 +67,6 @@ def masked_conic_filter(values, mask, radius: int, fixed_structure_mask=None):
     filtered = jnp.where(mask, filtered, 0.0)
 
     return filtered, jnp.ones_like(mask)
-
-
-@jax.jit
-def smoothed_heaviside(value, beta, eta):
-    """
-    Smoothed Heaviside projection using tanh.
-    """
-    beta = jnp.maximum(beta, 1e-6)
-    # Use tanh projection: (tanh(beta*eta) + tanh(beta*(x-eta))) / (tanh(beta*eta) + tanh(beta*(1-eta)))
-    num = jnp.tanh(beta * eta) + jnp.tanh(beta * (value - eta))
-    den = jnp.tanh(beta * eta) + jnp.tanh(beta * (1.0 - eta))
-    return num / den
 
 
 @partial(jax.jit, static_argnames=["axis"])
@@ -223,6 +213,8 @@ def masked_morphological_filter(
         "radius",
         "filter_type",
         "morphology_operation",
+        "projection_type",
+        "ssp_smoothing_radius",
     ],
 )
 def transform_density(
@@ -235,6 +227,8 @@ def transform_density(
     morphology_operation="openclose",
     morphology_tau=0.05,
     fixed_structure_mask=None,
+    projection_type="heaviside",
+    ssp_smoothing_radius=0.55,
 ):
     """
     Full density transform: Filter -> Project (literature-standard).
@@ -244,6 +238,8 @@ def transform_density(
         filter_type: 'morphological' or 'conic' (recommended)
         morphology_operation: 'opening', 'closing', 'openclose'
         fixed_structure_mask: Optional mask for fixed structures
+        projection_type: 'heaviside' (default) or 'ssp'
+        ssp_smoothing_radius: SSP smoothing radius in grid-cell units
     """
     # Apply filter (returns hard-masked result)
     if filter_type == "morphological":
@@ -265,7 +261,13 @@ def transform_density(
 
     # Project
     # Note: Filters already apply hard masking, so no additional masking needed
-    projected = smoothed_heaviside(filtered, beta, eta)
+    projected = project_density(
+        filtered,
+        beta,
+        eta,
+        projection_type=projection_type,
+        ssp_smoothing_radius=ssp_smoothing_radius,
+    )
 
     return projected
 
@@ -276,6 +278,8 @@ def transform_density(
         "radius",
         "filter_type",
         "morphology_operation",
+        "projection_type",
+        "ssp_smoothing_radius",
     ],
 )
 def compute_parameter_gradient_vjp(
@@ -289,6 +293,8 @@ def compute_parameter_gradient_vjp(
     morphology_operation="openclose",
     morphology_tau=0.05,
     fixed_structure_mask=None,
+    projection_type="heaviside",
+    ssp_smoothing_radius=0.55,
 ):
     """
     Compute gradient w.r.t. design density using VJP.
@@ -307,6 +313,8 @@ def compute_parameter_gradient_vjp(
             morphology_operation,
             morphology_tau,
             fixed_structure_mask,
+            projection_type,
+            ssp_smoothing_radius,
         )
 
     # Compute VJP

--- a/beamz/optimization/projections.py
+++ b/beamz/optimization/projections.py
@@ -1,0 +1,132 @@
+"""Projection methods for topology optimization densities."""
+
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+
+VALID_PROJECTION_TYPES = ("heaviside", "ssp")
+
+
+def validate_projection_options(
+    projection_type: str, ssp_smoothing_radius: float = 0.55
+) -> None:
+    """Validate projection configuration shared by transform and manager APIs."""
+    if projection_type not in VALID_PROJECTION_TYPES:
+        allowed = "', '".join(VALID_PROJECTION_TYPES)
+        raise ValueError(
+            f"Unknown projection_type: {projection_type}. Use '{allowed}'."
+        )
+
+    if ssp_smoothing_radius <= 0:
+        raise ValueError(
+            "ssp_smoothing_radius must be positive, "
+            f"got {ssp_smoothing_radius!r}."
+        )
+
+
+@jax.jit
+def smoothed_heaviside(value, beta, eta):
+    """Smoothed Heaviside projection using tanh."""
+    beta = jnp.asarray(beta)
+    beta_is_inf = jnp.isinf(beta)
+    finite_beta = jnp.where(beta_is_inf, 1.0, jnp.maximum(beta, 1e-6))
+
+    num = jnp.tanh(finite_beta * eta) + jnp.tanh(finite_beta * (value - eta))
+    den = jnp.tanh(finite_beta * eta) + jnp.tanh(finite_beta * (1.0 - eta))
+    projected = num / den
+
+    hard_threshold = jnp.where(value > eta, 1.0, 0.0)
+    return jnp.where(beta_is_inf, hard_threshold, projected)
+
+
+def subpixel_smoothed_projection(
+    value, beta, eta, ssp_smoothing_radius: float = 0.55
+):
+    """Apply Hammond SSP1 projection to a smooth 2D density field.
+
+    The input should already be smooth or filtered. The smoothing radius is in
+    density-grid cell units.
+    """
+    value = jnp.asarray(value)
+    if value.ndim != 2:
+        raise ValueError(
+            "subpixel_smoothed_projection expects a 2D array, "
+            f"got shape {value.shape}."
+        )
+    validate_projection_options("ssp", ssp_smoothing_radius)
+    return _subpixel_smoothed_projection_jit(
+        value, beta, eta, float(ssp_smoothing_radius)
+    )
+
+
+@partial(jax.jit, static_argnames=["ssp_smoothing_radius"])
+def _subpixel_smoothed_projection_jit(
+    value, beta, eta, ssp_smoothing_radius: float
+):
+    projected = smoothed_heaviside(value, beta, eta)
+
+    grad_y, grad_x = jnp.gradient(value)
+    grad_norm_squared = grad_y**2 + grad_x**2
+    nonzero_norm = jnp.abs(grad_norm_squared) > 1e-12
+
+    grad_norm = jnp.sqrt(jnp.where(nonzero_norm, grad_norm_squared, 1.0))
+    grad_norm_eff = jnp.where(nonzero_norm, grad_norm, 1.0)
+
+    distance = (eta - value) / grad_norm_eff
+    needs_smoothing = nonzero_norm & (jnp.abs(distance) < ssp_smoothing_radius)
+
+    relative_distance = jnp.where(
+        needs_smoothing, distance / ssp_smoothing_radius, 0.0
+    )
+    fill_fraction = jnp.where(
+        needs_smoothing,
+        (
+            0.5
+            - 15.0 / 16.0 * relative_distance
+            + 5.0 / 8.0 * relative_distance**3
+            - 3.0 / 16.0 * relative_distance**5
+        ),
+        1.0,
+    )
+    fill_fraction_neg = jnp.where(
+        needs_smoothing,
+        (
+            0.5
+            + 15.0 / 16.0 * relative_distance
+            - 5.0 / 8.0 * relative_distance**3
+            + 3.0 / 16.0 * relative_distance**5
+        ),
+        1.0,
+    )
+
+    lower = value - ssp_smoothing_radius * grad_norm_eff * fill_fraction
+    upper = value + ssp_smoothing_radius * grad_norm_eff * fill_fraction_neg
+
+    lower_projected = smoothed_heaviside(lower, beta, eta)
+    upper_projected = smoothed_heaviside(upper, beta, eta)
+
+    smoothed = (1.0 - fill_fraction) * lower_projected + (
+        fill_fraction * upper_projected
+    )
+    result = jnp.where(needs_smoothing, smoothed, projected)
+
+    is_binary_input = jnp.all((value == 0.0) | (value == 1.0))
+    return jnp.where(is_binary_input, projected, result)
+
+
+def project_density(
+    value,
+    beta,
+    eta,
+    projection_type: str = "heaviside",
+    ssp_smoothing_radius: float = 0.55,
+):
+    """Project a filtered density using the selected projection method."""
+    validate_projection_options(projection_type, ssp_smoothing_radius)
+
+    if projection_type == "heaviside":
+        return smoothed_heaviside(value, beta, eta)
+    return subpixel_smoothed_projection(
+        value, beta, eta, ssp_smoothing_radius=ssp_smoothing_radius
+    )

--- a/beamz/optimization/topology.py
+++ b/beamz/optimization/topology.py
@@ -11,6 +11,7 @@ from beamz.design.materials import Material
 from beamz.design.meshing import RegularGrid
 
 from .autodiff import compute_parameter_gradient_vjp, transform_density
+from .projections import validate_projection_options
 
 
 class TopologyManager:
@@ -33,6 +34,8 @@ class TopologyManager:
         learning_rate: float = 0.1,
         filter_radius: float = 0.0,
         projection_eta: float = 0.5,
+        projection_type: str = "heaviside",
+        ssp_smoothing_radius: float = 0.55,
         beta_schedule: tuple[float, float] = (1.0, 20.0),
         eps_min: float = 1.0,
         eps_max: float = 12.0,
@@ -46,11 +49,14 @@ class TopologyManager:
             filter_radius: Filter radius in physical units (e.g. microns).
                            Controls minimum feature size AND boundary smoothness.
                            Recommended: 0.25-0.35 µm for smooth, rounded structures.
+            projection_type: 'heaviside' (default) or 'ssp'.
+            ssp_smoothing_radius: SSP smoothing radius in density-grid cell units.
             filter_type: 'conic' (recommended, geometric constraints) or 'morphological'.
             morphology_operation: 'opening', 'closing', or 'openclose' (for morphological filter).
         """
         self.design = design
         self.mask = region_mask.astype(bool)
+        validate_projection_options(projection_type, ssp_smoothing_radius)
 
         # Setup optimizer using optax (JAX-native)
         try:
@@ -75,6 +81,8 @@ class TopologyManager:
         # Parameters
         self.filter_radius = filter_radius
         self.projection_eta = projection_eta
+        self.projection_type = projection_type
+        self.ssp_smoothing_radius = ssp_smoothing_radius
         self.beta_start, self.beta_end = beta_schedule
         self.eps_min = eps_min
         self.eps_max = eps_max
@@ -159,6 +167,8 @@ class TopologyManager:
             morphology_operation=self.morphology_operation,
             morphology_tau=self.morphology_smooth_tau,
             fixed_structure_mask=fixed_jax,
+            projection_type=self.projection_type,
+            ssp_smoothing_radius=self.ssp_smoothing_radius,
         )
         return np.array(p_jax)
 
@@ -204,6 +214,8 @@ class TopologyManager:
             morphology_operation=self.morphology_operation,
             morphology_tau=self.morphology_smooth_tau,
             fixed_structure_mask=fixed_jax,
+            projection_type=self.projection_type,
+            ssp_smoothing_radius=self.ssp_smoothing_radius,
         )
         grad_param = np.array(grad_param_jax)
 

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -163,6 +163,63 @@ class TestDensityTransformationPipeline:
                 f"{filter_type}: transform exceeded 1.0"
             )
 
+    def test_transform_density_ssp_conic_pipeline(self):
+        """SSP projection should work after the conic filter path."""
+        np.random.seed(42)
+        density = jnp.array(np.random.rand(10, 10))
+        mask = jnp.ones((10, 10), dtype=bool)
+
+        physical = transform_density(
+            density,
+            mask,
+            beta=jnp.inf,
+            eta=0.5,
+            radius=1,
+            filter_type="conic",
+            projection_type="ssp",
+        )
+
+        assert physical.shape == density.shape
+        assert jnp.all(jnp.isfinite(physical))
+        assert jnp.min(physical) >= -1e-6
+        assert jnp.max(physical) <= 1.0 + 1e-6
+
+    def test_transform_density_ssp_morphological_pipeline(self):
+        """SSP projection should be accepted after morphological filters."""
+        np.random.seed(42)
+        density = jnp.array(np.random.rand(8, 8))
+        mask = jnp.ones((8, 8), dtype=bool)
+
+        physical = transform_density(
+            density,
+            mask,
+            beta=4.0,
+            eta=0.5,
+            radius=1,
+            filter_type="morphological",
+            morphology_operation="opening",
+            projection_type="ssp",
+        )
+
+        assert physical.shape == density.shape
+        assert jnp.all(jnp.isfinite(physical))
+        assert jnp.min(physical) >= -1e-6
+        assert jnp.max(physical) <= 1.0 + 1e-6
+
+    def test_transform_density_rejects_unknown_projection_type(self):
+        density = jnp.ones((4, 4)) * 0.5
+        mask = jnp.ones((4, 4), dtype=bool)
+
+        with pytest.raises(ValueError, match="Unknown projection_type"):
+            transform_density(
+                density,
+                mask,
+                beta=1.0,
+                eta=0.5,
+                radius=0,
+                projection_type="tanh",
+            )
+
 
 @pytest.mark.optimization
 class TestGradientComputation:
@@ -339,6 +396,27 @@ class TestGradientComputation:
             "Morphological VJP gradient contains inf/nan"
         )
 
+    def test_vjp_gradient_ssp_projection(self):
+        """VJP should work with SSP projection."""
+        density = jnp.tile(jnp.linspace(0.0, 1.0, 8), (8, 1))
+        mask = jnp.ones((8, 8), dtype=bool)
+        grad_physical = jnp.ones((8, 8))
+
+        grad_vjp = compute_parameter_gradient_vjp(
+            density,
+            grad_physical,
+            mask,
+            beta=jnp.inf,
+            eta=0.5,
+            radius=1,
+            filter_type="conic",
+            projection_type="ssp",
+        )
+
+        assert grad_vjp.shape == density.shape
+        assert jnp.all(jnp.isfinite(grad_vjp))
+        assert jnp.max(jnp.abs(grad_vjp)) > 1e-6
+
 
 @pytest.mark.optimization
 class TestMaterialPenalty:
@@ -489,3 +567,45 @@ class TestTopologyManagerResolution:
 
         manager = TopologyManager(design=design, region_mask=mask, resolution=None)
         assert np.isclose(manager.resolution, 1.0e-6)
+
+
+@pytest.mark.optimization
+class TestTopologyManagerProjection:
+    """Projection settings should be explicit and consistently threaded."""
+
+    def test_rejects_unknown_projection_type_at_construction(self):
+        design = Design(
+            width=2.0e-6, height=2.0e-6, material=Material(permittivity=1.0)
+        )
+        mask = np.ones((2, 2), dtype=bool)
+
+        with pytest.raises(ValueError, match="Unknown projection_type"):
+            TopologyManager(
+                design=design,
+                region_mask=mask,
+                resolution=1.0e-6,
+                projection_type="tanh",
+            )
+
+    def test_ssp_projection_settings_are_used_for_density(self):
+        design = Design(
+            width=4.0e-6, height=4.0e-6, material=Material(permittivity=1.0)
+        )
+        mask = np.ones((4, 4), dtype=bool)
+        manager = TopologyManager(
+            design=design,
+            region_mask=mask,
+            resolution=1.0e-6,
+            filter_radius=1.0e-6,
+            projection_type="ssp",
+            ssp_smoothing_radius=0.55,
+        )
+        manager.design_density = np.tile(np.linspace(0.0, 1.0, 4), (4, 1))
+
+        physical = manager.get_physical_density(beta=np.inf)
+
+        assert manager.projection_type == "ssp"
+        assert np.all(np.isfinite(physical))
+        assert physical.shape == manager.design_density.shape
+        assert np.min(physical) >= -1e-6
+        assert np.max(physical) <= 1.0 + 1e-6

--- a/tests/test_optimization_projections.py
+++ b/tests/test_optimization_projections.py
@@ -1,0 +1,108 @@
+"""Projection method tests for topology optimization."""
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import beamz.optimization as optimization
+from beamz.optimization.projections import (
+    smoothed_heaviside,
+    subpixel_smoothed_projection,
+)
+
+
+@pytest.mark.optimization
+class TestSmoothedHeaviside:
+    """Tests for the tanh smoothed Heaviside projection."""
+
+    def test_beta_inf_returns_finite_hard_threshold(self):
+        values = jnp.array([0.25, 0.5, 0.75])
+
+        projected = smoothed_heaviside(values, beta=jnp.inf, eta=0.5)
+
+        assert jnp.all(jnp.isfinite(projected))
+        assert jnp.array_equal(projected, jnp.array([0.0, 0.0, 1.0]))
+
+
+@pytest.mark.optimization
+class TestSubpixelSmoothedProjection:
+    """Tests for Hammond SSP1 projection behavior."""
+
+    def test_exported_from_optimization_namespace(self):
+        assert (
+            optimization.subpixel_smoothed_projection is subpixel_smoothed_projection
+        )
+
+    def test_beta_inf_keeps_binary_input_binary(self):
+        density = jnp.array(
+            [
+                [0.0, 0.0, 1.0],
+                [0.0, 1.0, 1.0],
+                [0.0, 1.0, 1.0],
+            ]
+        )
+
+        projected = subpixel_smoothed_projection(density, beta=jnp.inf, eta=0.5)
+
+        assert jnp.all(jnp.isfinite(projected))
+        assert jnp.all((projected == 0.0) | (projected == 1.0))
+
+    def test_rejects_non_2d_input(self):
+        density = jnp.ones((2, 2, 2))
+
+        with pytest.raises(ValueError, match="2D"):
+            subpixel_smoothed_projection(density, beta=1.0, eta=0.5)
+
+    @pytest.mark.parametrize("value", [0.25, 0.5, 0.75])
+    def test_constant_inputs_are_finite(self, value):
+        density = jnp.full((4, 4), value)
+
+        projected = subpixel_smoothed_projection(density, beta=5.0, eta=0.5)
+
+        assert jnp.all(jnp.isfinite(projected))
+        assert jnp.min(projected) >= -1e-6
+        assert jnp.max(projected) <= 1.0 + 1e-6
+
+    def test_beta_inf_smooth_disk_is_finite_and_bounded(self):
+        coords = jnp.linspace(-1.0, 1.0, 31)
+        yy, xx = jnp.meshgrid(coords, coords, indexing="ij")
+        distance = jnp.sqrt(xx**2 + yy**2)
+        density = jnp.clip(0.5 + (0.45 - distance) / 0.2, 0.0, 1.0)
+
+        projected = subpixel_smoothed_projection(density, beta=jnp.inf, eta=0.5)
+
+        assert jnp.all(jnp.isfinite(projected))
+        assert jnp.min(projected) >= -1e-6
+        assert jnp.max(projected) <= 1.0 + 1e-6
+        assert projected[15, 15] == 1.0
+        assert projected[0, 0] == 0.0
+
+    def test_beta_inf_has_nonzero_interface_gradient(self):
+        density = jnp.tile(jnp.linspace(0.0, 1.0, 21), (21, 1))
+
+        def objective(values):
+            projected = subpixel_smoothed_projection(
+                values.reshape(density.shape), beta=jnp.inf, eta=0.5
+            )
+            return jnp.sum(projected)
+
+        grad = jax.grad(objective)(density.ravel())
+
+        assert jnp.all(jnp.isfinite(grad))
+        assert jnp.max(jnp.abs(grad)) > 1e-6
+
+    def test_away_from_interface_matches_heaviside(self):
+        density = jnp.array([[0.1, 0.15, 0.2], [0.1, 0.15, 0.2]])
+
+        projected = subpixel_smoothed_projection(density, beta=4.0, eta=0.5)
+        expected = smoothed_heaviside(density, beta=4.0, eta=0.5)
+
+        assert jnp.allclose(projected, expected, atol=1e-6)
+
+    def test_rejects_non_positive_smoothing_radius(self):
+        density = jnp.ones((3, 3))
+
+        with pytest.raises(ValueError, match="ssp_smoothing_radius"):
+            subpixel_smoothed_projection(
+                density, beta=1.0, eta=0.5, ssp_smoothing_radius=0.0
+            )


### PR DESCRIPTION
Closes #1.

## Summary

Adds Hammond subpixel-smoothed projection (SSP1) as an optional topology optimization projection path.

## What changed

- Added `projection_type="ssp"` alongside the existing default `projection_type="heaviside"`.
- Added `beamz.optimization.subpixel_smoothed_projection`.
- Moved projection helpers into `beamz.optimization.projections`.
- Threaded projection selection through `transform_density`, VJP gradient computation, and `TopologyManager`.
- Preserved existing default Heaviside behavior.
- Added projection unit tests and optimization pipeline/manager integration tests.
- Documented the new projection option in the optimization README.

## Notes

The SSP implementation follows the Hammond SSP1 form used by NanoComp SSP, Tidy3D, and FDTDX: gradient-based interface distance, quintic fill fractions, lower/upper projected samples, and blended smoothing near interfaces.

`ssp_smoothing_radius` is expressed in density-grid cell units. The default is `0.55`.

No new runtime, optional, or test dependencies are added.

<img width="3150" height="1548" alt="beamz_vs_nanocomp_ssp_beta_inf_gradient" src="https://github.com/user-attachments/assets/d42cd677-d6db-4d6b-92d0-86a867530a91" />

## Validation

- `uv run --with ruff ruff check beamz/optimization/projections.py beamz/optimization/autodiff.py beamz/optimization/topology.py beamz/optimization/__init__.py tests/test_optimization.py tests/test_optimization_projections.py`
- `uv run --with pytest pytest tests/test_optimization.py tests/test_optimization_projections.py -q`
- `uv run --with pytest pytest -q`

Results:

- Ruff passed
- Focused optimization/projection tests: `35 passed`
- Full suite: `604 passed, 1 skipped, 2 warnings`