### PR TITLE
[Grid]: Consume full Farjadpour tensors in FDTD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ aliases.
 ### Added
 
 - Added lossless full-tensor Farjadpour permittivity updates for 2D TE and 3D
-  FDTD, while retaining the explicit diagonal update policy.
+  FDTD, with inverse diagonals at E supports and stable average-multiply-average
+  cross coupling at shared grid nodes, while retaining the explicit diagonal
+  update policy.
 - Integrated the complete MicroMode finite-difference eigensolver into
   `beamz.devices.modes`, including the latest guarded Yee-grid refinement and
   validation work from `beamzorg/micromode@80c57d8`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ aliases.
 
 ### Added
 
+- Added lossless full-tensor Farjadpour permittivity updates for 2D TE and 3D
+  FDTD, while retaining the explicit diagonal update policy.
 - Integrated the complete MicroMode finite-difference eigensolver into
   `beamz.devices.modes`, including the latest guarded Yee-grid refinement and
   validation work from `beamzorg/micromode@80c57d8`.
@@ -31,6 +33,9 @@ aliases.
 
 ### Changed
 
+- Farjadpour smoothing is now the default: standalone rasterization retains full
+  tensors and simulations use the diagonal policy unless full coupling is
+  requested explicitly.
 - Mode sources, monitors, and ports now share `ModeSpec` and `ModeData` from
   `beamz.devices.modes`; the former source import paths remain compatibility
   re-exports.

--- a/beamz/design/discretization.py
+++ b/beamz/design/discretization.py
@@ -53,6 +53,8 @@ class MaterialGrid:
         Componentwise material arrays already sampled at Yee supports.
     tensors : mapping, optional
         Packed symmetric cell tensors retained for compatible mode solving.
+    yee_tensors : mapping, optional
+        Full symmetric permittivity tensors sampled at electric Yee supports.
     smoothing : str, default="volume"
         Raster smoothing policy that produced the coefficients.
     origin : tuple of float, default=(0, 0, 0)
@@ -76,6 +78,7 @@ class MaterialGrid:
     smoothing: str = "volume"
     origin: tuple[float, float, float] = (0.0, 0.0, 0.0)
     polarization: Literal["tm", "te"] | None = None
+    yee_tensors: Mapping[str, npt.ArrayLike] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "permittivity", readonly_array(self.permittivity))
@@ -104,7 +107,7 @@ class MaterialGrid:
                 continue
             if actual != shape:
                 raise ValueError(f"{name} has shape {actual}, expected {shape}.")
-        for name in ("yee_materials", "tensors"):
+        for name in ("yee_materials", "tensors", "yee_tensors"):
             values = {
                 str(key): readonly_array(value)
                 for key, value in dict(getattr(self, name)).items()
@@ -157,6 +160,24 @@ class MaterialGrid:
                 or shape[1:] != self.shape
             ):
                 raise ValueError(f"{name} tensor has invalid compact shape {shape}.")
+        unknown_yee_tensors = set(self.yee_tensors) - {"eps_x", "eps_y", "eps_z"}
+        if unknown_yee_tensors:
+            raise ValueError(
+                "Unknown Yee permittivity tensors: "
+                f"{', '.join(sorted(unknown_yee_tensors))}."
+            )
+        if self.yee_tensors:
+            from beamz.lattice import component_shapes
+
+            shapes = component_shapes(self.shape, self.polarization or "tm")
+            for name, values in self.yee_tensors.items():
+                expected = shapes[{"eps_x": "Ex", "eps_y": "Ey", "eps_z": "Ez"}[name]]
+                actual = np.asarray(values).shape
+                if actual[0:1] not in ((1,), (3,), (6,)) or actual[1:] != expected:
+                    raise ValueError(
+                        f"{name} tensor has shape {actual}, expected compact "
+                        f"(1|3|6, {', '.join(map(str, expected))})."
+                    )
 
     @classmethod
     def from_raster_result(
@@ -259,15 +280,14 @@ class MaterialGrid:
                 "BeamZ Simulation requires one uniform spacing on every active axis."
             )
         smoothing = str(getattr(result, "smoothing", "volume"))
-        if smoothing == "farjadpour_full":
-            raise ValueError(
-                "BeamZ Simulation cannot consume full off-diagonal Farjadpour "
-                "tensors yet. Rasterize with smoothing='farjadpour_diagonal' "
-                "for the current componentwise FDTD engine."
-            )
         materials = {
             target: _support_diagonal(support_tensors[source], axis)
             for target, source, axis in component_specs
+        }
+        yee_tensors = {
+            target: np.asarray(support_tensors[source])
+            for target, source, _axis in component_specs
+            if target.startswith("eps_")
         }
         tensors = dict(getattr(result, "tensors", {}))
         missing_tensors = {"epsilon", "mu", "conductivity"} - set(tensors)
@@ -276,25 +296,33 @@ class MaterialGrid:
                 "RasterResult omits cell tensors: "
                 f"{', '.join(sorted(missing_tensors))}."
             )
-        if smoothing == "volume":
-            off_diagonal = max(
-                (
-                    float(np.max(np.abs(np.asarray(values)[3:])))
-                    for values in tensors.values()
-                    if np.asarray(values).shape[0] == 6
-                ),
-                default=0.0,
-            )
-            if off_diagonal > 1e-10:
-                raise ValueError(
-                    "BeamZ Simulation cannot silently discard off-diagonal material "
-                    "terms. Select smoothing='farjadpour_diagonal' to request an "
-                    "explicit diagonal projection, or use the standalone result."
-                )
-
         epsilon_tensor = np.asarray(tensors["epsilon"])
         mu_tensor = np.asarray(tensors["mu"])
         conductivity_tensor = np.asarray(tensors["conductivity"])
+        if np.any(np.abs(_tensor_off_diagonal(conductivity_tensor)) > 1e-10):
+            raise ValueError(
+                "BeamZ's full-tensor update does not support off-diagonal "
+                "conductivity. Use diagonal conductivity coefficients."
+            )
+        if (
+            dimensions == 2
+            and epsilon_tensor.shape[0] == 6
+            and np.any(np.abs(epsilon_tensor[[4, 5]]) > 1e-10)
+        ):
+            raise ValueError(
+                "A 2D simulation requires permittivity without xz or yz coupling."
+            )
+        has_full_permittivity = dimensions == 3 or polarization == "te"
+        has_full_permittivity = has_full_permittivity and any(
+            np.any(np.abs(np.asarray(values)[3:]) > 1e-10)
+            for values in yee_tensors.values()
+        )
+        if not has_full_permittivity:
+            yee_tensors = {}
+        if has_full_permittivity and np.any(np.abs(conductivity_tensor) > 1e-10):
+            raise ValueError(
+                "Full-tensor permittivity currently requires zero conductivity."
+            )
         mu_diagonal = _tensor_diagonal(mu_tensor)
         if not (
             np.allclose(mu_diagonal, 1.0, rtol=1e-10, atol=1e-12)
@@ -328,6 +356,9 @@ class MaterialGrid:
                 name: np.asarray(value)[0] for name, value in materials.items()
             }
             tensors = {name: np.asarray(value)[:, 0] for name, value in tensors.items()}
+            yee_tensors = {
+                name: np.asarray(value)[:, 0] for name, value in yee_tensors.items()
+            }
         return cls(
             epsilon,
             conductivity,
@@ -343,6 +374,7 @@ class MaterialGrid:
                 float(np.asarray(edges[2])[0]),
             ),
             polarization if dimensions == 2 else None,
+            yee_tensors,
         )
 
     def field_arrays(self) -> tuple[npt.ArrayLike, npt.ArrayLike, npt.ArrayLike]:
@@ -355,7 +387,7 @@ class MaterialGrid:
 
         if not self.yee_materials:
             return False
-        if self.smoothing == "farjadpour_diagonal":
+        if self.smoothing == "farjadpour_diagonal" or self.uses_full_permittivity:
             return True
         for name in ("epsilon", "conductivity"):
             if name not in self.tensors:
@@ -368,6 +400,15 @@ class MaterialGrid:
                 return True
         return False
 
+    @property
+    def uses_full_permittivity(self) -> bool:
+        """Return whether propagation needs off-diagonal electric coupling."""
+
+        return any(
+            np.any(np.abs(np.asarray(values)[3:]) > 1e-10)
+            for values in self.yee_tensors.values()
+        )
+
     def canonical_spec(self):
         """Return values defining material-grid cache identity."""
         return (
@@ -379,6 +420,7 @@ class MaterialGrid:
             self.smoothing,
             self.origin,
             self.polarization,
+            self.yee_tensors,
         )
 
     def __eq__(self, other):

--- a/beamz/design/discretization.py
+++ b/beamz/design/discretization.py
@@ -54,7 +54,8 @@ class MaterialGrid:
     tensors : mapping, optional
         Packed symmetric cell tensors retained for compatible mode solving.
     yee_tensors : mapping, optional
-        Full symmetric permittivity tensors sampled at electric Yee supports.
+        Full symmetric permittivity tensors sampled at electric Yee supports and,
+        for cross coupling, at the shared grid nodes.
     smoothing : str, default="volume"
         Raster smoothing policy that produced the coefficients.
     origin : tuple of float, default=(0, 0, 0)
@@ -160,7 +161,12 @@ class MaterialGrid:
                 or shape[1:] != self.shape
             ):
                 raise ValueError(f"{name} tensor has invalid compact shape {shape}.")
-        unknown_yee_tensors = set(self.yee_tensors) - {"eps_x", "eps_y", "eps_z"}
+        unknown_yee_tensors = set(self.yee_tensors) - {
+            "eps_x",
+            "eps_y",
+            "eps_z",
+            "eps_node",
+        }
         if unknown_yee_tensors:
             raise ValueError(
                 "Unknown Yee permittivity tensors: "
@@ -171,7 +177,11 @@ class MaterialGrid:
 
             shapes = component_shapes(self.shape, self.polarization or "tm")
             for name, values in self.yee_tensors.items():
-                expected = shapes[{"eps_x": "Ex", "eps_y": "Ey", "eps_z": "Ez"}[name]]
+                expected = (
+                    tuple(value + 1 for value in self.shape)
+                    if name == "eps_node"
+                    else shapes[{"eps_x": "Ex", "eps_y": "Ey", "eps_z": "Ez"}[name]]
+                )
                 actual = np.asarray(values).shape
                 if actual[0:1] not in ((1,), (3,), (6,)) or actual[1:] != expected:
                     raise ValueError(
@@ -317,7 +327,14 @@ class MaterialGrid:
             np.any(np.abs(np.asarray(values)[3:]) > 1e-10)
             for values in yee_tensors.values()
         )
-        if not has_full_permittivity:
+        if has_full_permittivity:
+            if "epsilon_node" not in support_tensors:
+                raise ValueError(
+                    "Full-tensor permittivity requires the node-centered "
+                    "off-diagonal raster tensor."
+                )
+            yee_tensors["eps_node"] = np.asarray(support_tensors["epsilon_node"])
+        else:
             yee_tensors = {}
         if has_full_permittivity and np.any(np.abs(conductivity_tensor) > 1e-10):
             raise ValueError(

--- a/beamz/design/raster/README.md
+++ b/beamz/design/raster/README.md
@@ -50,10 +50,12 @@ conductivity remains volume averaged.
 
 `RasterResult` contains immutable grid edges, cell-centered `tensors`, summary
 diagnostics, and constitutive `yee_tensors` integrated independently over the
-Ex/Ey/Ez and Hx/Hy/Hz dual volumes. Tensor arrays use one leading component for
-isotropic materials, three `(xx, yy, zz)` components for diagonal materials,
-and six `(xx, yy, zz, xy, xz, yz)` components for full symmetric materials. It
-does not produce dense material-ID, boundary-mask, or error arrays.
+Ex/Ey/Ez and Hx/Hy/Hz dual volumes. Full smoothing also integrates epsilon at
+the grid nodes shared by the off-diagonal electric terms. Tensor arrays use one
+leading component for isotropic materials, three `(xx, yy, zz)` components for
+diagonal materials, and six `(xx, yy, zz, xy, xz, yz)` components for full
+symmetric materials. It does not produce dense material-ID, boundary-mask, or
+error arrays.
 
 Farjadpour smoothing is applied only when the surface patches crossing one Yee
 support form a reliable, sign-invariant lamination axis. Corners, non-coplanar
@@ -76,10 +78,11 @@ corrupt-cache recovery.
 
 Standalone rasterization accepts uniform and nonuniform rectilinear grids.
 BeamZ's FDTD engine requires a single uniform resolution. It extracts the target
-diagonal from each `farjadpour_diagonal` support tensor or precomputes inverse
-tensor rows from `farjadpour_full` results. Full coupling currently requires
-zero electric conductivity and unit permeability; use CPML rather than a
-conductive sponge PML with that mode.
+diagonal from each electric support tensor. For `farjadpour_full`, it compiles
+the inverse diagonal at each E support and the inverse cross terms at shared
+grid nodes, then uses the paper's average-multiply-average coupling. Full
+coupling currently requires zero electric conductivity and unit permeability;
+use CPML rather than a conductive sponge PML with that mode.
 
 Imported scenes use the same simulation workflow as BeamZ designs; the
 solver-specific conversion stays internal:

--- a/beamz/design/raster/README.md
+++ b/beamz/design/raster/README.md
@@ -42,7 +42,8 @@ The public package exports:
 `RasterOptions` has three choices: `quality` (`fast`, `balanced`, or
 `reference`), `smoothing` (`volume`, `farjadpour_diagonal`, or
 `farjadpour_full`), and `components` (`all`, `two_dimensional_tm`, or
-`two_dimensional_te`). Adaptive
+`two_dimensional_te`). Standalone rasterization defaults to `farjadpour_full`.
+Adaptive
 tolerances and threading remain internal. Farjadpour modes use the generalized
 local-interface tensor transform for permittivity and permeability;
 conductivity remains volume averaged.
@@ -74,11 +75,11 @@ corrupt-cache recovery.
 ## Standalone versus simulation use
 
 Standalone rasterization accepts uniform and nonuniform rectilinear grids.
-BeamZ's current FDTD engine requires a single uniform resolution and supports
-componentwise diagonal material coefficients. `MaterialGrid.from_raster_result()`
-therefore rejects nonuniform and `farjadpour_full` results. It extracts the
-target diagonal from each `farjadpour_diagonal` support tensor and never
-silently discards off-diagonal terms.
+BeamZ's FDTD engine requires a single uniform resolution. It extracts the target
+diagonal from each `farjadpour_diagonal` support tensor or precomputes inverse
+tensor rows from `farjadpour_full` results. Full coupling currently requires
+zero electric conductivity and unit permeability; use CPML rather than a
+conductive sponge PML with that mode.
 
 Imported scenes use the same simulation workflow as BeamZ designs; the
 solver-specific conversion stays internal:
@@ -110,27 +111,27 @@ Pre-sampled
 spatial coefficients enter `Simulation` directly as `MaterialGrid`; there is no
 second Python geometry rasterizer or engine-selection switch.
 
-Normal simulations retain volume averaging unless an explicit native policy is
-requested:
+Normal simulations use diagonal Farjadpour smoothing. Full lossless coupling can
+be requested explicitly:
 
 ```python
 import beamz
 
 simulation = beamz.Simulation(
     design=design,
-    raster_options=raster.RasterOptions(smoothing="farjadpour_diagonal"),
+    raster_options=raster.RasterOptions(smoothing="farjadpour_full"),
     run_time=1e-12,
 )
 ```
 
-The compiler consumes those native Yee arrays directly. Full Farjadpour tensors,
-nonuniform grids, off-diagonal volume tensors, and non-unit permeability fail at
-the `MaterialGrid` boundary with a capability-specific message. Conductive
-materials propagate in FDTD but are rejected for `ModeSource` until the mode
-bridge represents their frequency-dependent complex permittivity. The current
-2D and public convenience mode solvers likewise reject direct-Yee grids rather
-than solving a cell-centered approximation; the 3D launch planner retains its
-Yee-aware refinement path.
+The compiler consumes those native Yee arrays directly. Nonuniform grids,
+full-tensor conductivity, full permittivity combined with conductivity, and
+non-unit permeability fail with a capability-specific message. Conductive
+diagonal materials propagate in FDTD but are rejected for `ModeSource` until
+the mode bridge represents their frequency-dependent complex permittivity. The
+current 2D and public convenience mode solvers use the cell-tensor approximation
+for diagonal Farjadpour grids and reject full off-diagonal coupling; the 3D
+launch planner retains its Yee-aware refinement path.
 
 ## Importers
 

--- a/beamz/design/raster/engine.py
+++ b/beamz/design/raster/engine.py
@@ -20,7 +20,7 @@ from .schema import _CACHE_SCHEMA_VERSION, _ENGINE_VERSION, Grid, Scene
 @dataclass(frozen=True, slots=True)
 class RasterOptions:
     quality: str = "balanced"
-    smoothing: str = "volume"
+    smoothing: str = "farjadpour_full"
     components: str = "all"
 
     def __post_init__(self) -> None:

--- a/beamz/design/raster/integration.py
+++ b/beamz/design/raster/integration.py
@@ -46,7 +46,7 @@ def _rasterize_design(
     progress: bool = False,
     resolution_z: float | None = None,
     quality: str = "balanced",
-    smoothing: str = "volume",
+    smoothing: str = "farjadpour_diagonal",
     polarization: str = "tm",
     cache_directory: str | Path | None = None,
 ):

--- a/beamz/design/raster/result.py
+++ b/beamz/design/raster/result.py
@@ -49,6 +49,7 @@ def _yee_tensor_shapes(
         "epsilon_ex": ex,
         "epsilon_ey": ey,
         "epsilon_ez": ez,
+        "epsilon_node": (nz + 1, ny + 1, nx + 1),
         "conductivity_ex": ex,
         "conductivity_ey": ey,
         "conductivity_ez": ez,

--- a/beamz/design/raster/schema.py
+++ b/beamz/design/raster/schema.py
@@ -13,7 +13,7 @@ from beamz.design.materials import Material
 
 from . import _native  # type: ignore[attr-defined]
 
-_CACHE_SCHEMA_VERSION = 3
+_CACHE_SCHEMA_VERSION = 4
 _ENGINE_VERSION = str(_native.ENGINE_VERSION)
 
 

--- a/beamz/devices/sources/mode_launch.py
+++ b/beamz/devices/sources/mode_launch.py
@@ -366,9 +366,20 @@ def _plan_2d_mode_source(
     if snapped.companion_index is None:
         raise ValueError("A mode source launch needs a companion Yee plane.")
     offset_idx = int(snapped.companion_index)
-    eps_profile = (
-        permittivity[:, center_idx] if axis == "x" else permittivity[center_idx, :]
-    )
+    material_grid = getattr(fields, "material_grid", None)
+    if material_grid is not None and material_grid.uses_direct_yee_materials:
+        component = (
+            "eps_z" if polarization == "tm" else ("eps_y" if axis == "x" else "eps_x")
+        )
+        direct = np.asarray(getattr(fields, component))
+        normal_index = min(center_idx, direct.shape[1 if axis == "x" else 0] - 1)
+        eps_profile = (
+            direct[:, normal_index] if axis == "x" else direct[normal_index, :]
+        )
+    else:
+        eps_profile = (
+            permittivity[:, center_idx] if axis == "x" else permittivity[center_idx, :]
+        )
     omega = 2.0 * np.pi * source.frequency
     neff, e_mode, h_mode = _solve_2d_mode(
         source, eps_profile, omega, resolution, axis, polarization

--- a/beamz/devices/sources/solve.py
+++ b/beamz/devices/sources/solve.py
@@ -15,11 +15,10 @@ from .specs import plane_axis_and_spans
 def _require_cell_mode_materials(material_grid, *, operation: str) -> None:
     """Reject material grids whose propagation coefficients cannot be reproduced."""
 
-    if material_grid is not None and material_grid.uses_direct_yee_materials:
+    if material_grid is not None and material_grid.uses_full_permittivity:
         raise ValueError(
-            f"{operation} cannot yet reproduce direct Yee-support material "
-            "coefficients. Use volume-averaged isotropic materials or solve the "
-            "mode with a Yee-aware path."
+            f"{operation} cannot yet reproduce full off-diagonal permittivity. "
+            "Use farjadpour_diagonal or solve the mode with a full-tensor path."
         )
 
 

--- a/beamz/simulation/api.py
+++ b/beamz/simulation/api.py
@@ -308,7 +308,11 @@ def _rasterize_scene_for_simulation(
         raise TypeError("Simulation scene must be a raster Scene.")
     if not isinstance(raster_grid, Grid):
         raise TypeError("Simulation raster_grid must be a raster Grid.")
-    options = RasterOptions() if raster_options is None else raster_options
+    options = (
+        RasterOptions(smoothing="farjadpour_diagonal")
+        if raster_options is None
+        else raster_options
+    )
     if not isinstance(options, RasterOptions):
         raise TypeError("raster_options must be RasterOptions or None.")
     dimensions = 2 if raster_grid.shape[2] == 1 else 3
@@ -473,9 +477,9 @@ class Simulation:
         to retain raw acquisitions.
     raster_options : RasterOptions, optional
         Native raster quality and smoothing policy. Component selection remains
-        automatic for the simulation dimensionality. The default preserves volume
-        averaging; select ``smoothing="farjadpour_diagonal"`` for the explicit
-        projection supported by the current componentwise FDTD update.
+        automatic for the simulation dimensionality. Simulations default to
+        ``farjadpour_diagonal``; select ``farjadpour_full`` to retain lossless
+        off-diagonal electric coupling.
 
     Notes
     -----

--- a/beamz/simulation/compile.py
+++ b/beamz/simulation/compile.py
@@ -128,8 +128,8 @@ def _elide_zero_conductivity_grid(value):
     return value
 
 
-def _inverse_permittivity_row(values, row: int):
-    """Invert one packed symmetric tensor field and retain one matrix row."""
+def _inverse_permittivity_components(values):
+    """Invert a packed symmetric tensor field into six trailing components."""
 
     packed = np.asarray(values)
     xx, yy, zz, xy, xz, yz = packed
@@ -137,11 +137,14 @@ def _inverse_permittivity_row(values, row: int):
         xx * yy * zz + 2.0 * xy * xz * yz - xx * yz * yz - yy * xz * xz - zz * xy * xy
     )
     cofactors = (
-        (yy * zz - yz * yz, xz * yz - xy * zz, xy * yz - xz * yy),
-        (xz * yz - xy * zz, xx * zz - xz * xz, xy * xz - xx * yz),
-        (xy * yz - xz * yy, xy * xz - xx * yz, xx * yy - xy * xy),
+        yy * zz - yz * yz,
+        xx * zz - xz * xz,
+        xx * yy - xy * xy,
+        xz * yz - xy * zz,
+        xy * yz - xz * yy,
+        xy * xz - xx * yz,
     )
-    return jnp.asarray(np.stack(cofactors[int(row)], axis=-1) / determinant[..., None])
+    return jnp.asarray(np.stack(cofactors, axis=-1) / determinant[..., None])
 
 
 def _compile_cpml_plan(
@@ -513,7 +516,7 @@ def compile_simulation(request: SimulationRequest) -> CompiledProgram:
         )
         e_conductivity_x = e_conductivity_y = e_conductivity_z = empty3
         e_permittivity_x = e_permittivity_y = e_permittivity_z = empty3
-    empty_tensor = jnp.zeros((0,), dtype=jnp.float32)
+    empty_inverse = jnp.zeros((0,), dtype=jnp.float32)
     if request.materials.uses_full_permittivity:
         if any(
             np.any(np.asarray(value) != 0.0)
@@ -524,23 +527,29 @@ def compile_simulation(request: SimulationRequest) -> CompiledProgram:
                 "use CPML rather than conductive or sponge-PML materials."
             )
         support_tensors = request.materials.yee_tensors
-        e_inverse_tensor_x = (
-            _inverse_permittivity_row(support_tensors["eps_x"], 0)
+        e_inverse_diagonal_x = (
+            _inverse_permittivity_components(support_tensors["eps_x"])[..., 0]
             if "eps_x" in support_tensors
-            else empty_tensor
+            else empty_inverse
         )
-        e_inverse_tensor_y = (
-            _inverse_permittivity_row(support_tensors["eps_y"], 1)
+        e_inverse_diagonal_y = (
+            _inverse_permittivity_components(support_tensors["eps_y"])[..., 1]
             if "eps_y" in support_tensors
-            else empty_tensor
+            else empty_inverse
         )
-        e_inverse_tensor_z = (
-            _inverse_permittivity_row(support_tensors["eps_z"], 2)
+        e_inverse_diagonal_z = (
+            _inverse_permittivity_components(support_tensors["eps_z"])[..., 2]
             if "eps_z" in support_tensors
-            else empty_tensor
+            else empty_inverse
         )
+        e_inverse_offdiagonal = _inverse_permittivity_components(
+            support_tensors["eps_node"]
+        )[..., 3:]
     else:
-        e_inverse_tensor_x = e_inverse_tensor_y = e_inverse_tensor_z = empty_tensor
+        e_inverse_diagonal_x = e_inverse_diagonal_y = e_inverse_diagonal_z = (
+            empty_inverse
+        )
+        e_inverse_offdiagonal = empty_inverse
     # 5. Precompute the same packed recurrence record for every 2D or 3D derivative.
     cpml = _compile_cpml_plan(
         fields,
@@ -566,17 +575,18 @@ def compile_simulation(request: SimulationRequest) -> CompiledProgram:
         e_source_x=e_source_x,
         e_conductivity_x=e_conductivity_x,
         e_permittivity_x=e_permittivity_x,
-        e_inverse_tensor_x=e_inverse_tensor_x,
+        e_inverse_diagonal_x=e_inverse_diagonal_x,
         e_decay_y=e_decay_y,
         e_source_y=e_source_y,
         e_conductivity_y=e_conductivity_y,
         e_permittivity_y=e_permittivity_y,
-        e_inverse_tensor_y=e_inverse_tensor_y,
+        e_inverse_diagonal_y=e_inverse_diagonal_y,
         e_decay_z=e_decay_z,
         e_source_z=e_source_z,
         e_conductivity_z=e_conductivity_z,
         e_permittivity_z=e_permittivity_z,
-        e_inverse_tensor_z=e_inverse_tensor_z,
+        e_inverse_diagonal_z=e_inverse_diagonal_z,
+        e_inverse_offdiagonal=e_inverse_offdiagonal,
     )
     boundary = _compile_boundary(
         fields,
@@ -692,9 +702,10 @@ _REFERENCED_COEFFICIENTS = {
     "e_permittivity_x",
     "e_permittivity_y",
     "e_permittivity_z",
-    "e_inverse_tensor_x",
-    "e_inverse_tensor_y",
-    "e_inverse_tensor_z",
+    "e_inverse_diagonal_x",
+    "e_inverse_diagonal_y",
+    "e_inverse_diagonal_z",
+    "e_inverse_offdiagonal",
 }
 
 

--- a/beamz/simulation/compile.py
+++ b/beamz/simulation/compile.py
@@ -128,6 +128,22 @@ def _elide_zero_conductivity_grid(value):
     return value
 
 
+def _inverse_permittivity_row(values, row: int):
+    """Invert one packed symmetric tensor field and retain one matrix row."""
+
+    packed = np.asarray(values)
+    xx, yy, zz, xy, xz, yz = packed
+    determinant = (
+        xx * yy * zz + 2.0 * xy * xz * yz - xx * yz * yz - yy * xz * xz - zz * xy * xy
+    )
+    cofactors = (
+        (yy * zz - yz * yz, xz * yz - xy * zz, xy * yz - xz * yy),
+        (xz * yz - xy * zz, xx * zz - xz * xz, xy * xz - xx * yz),
+        (xy * yz - xz * yy, xy * xz - xx * yz, xx * yy - xy * xy),
+    )
+    return jnp.asarray(np.stack(cofactors[int(row)], axis=-1) / determinant[..., None])
+
+
 def _compile_cpml_plan(
     fields, *, dt, is_3d, metallic_edges, polarization_2d: str = "tm"
 ) -> CpmlPlan:
@@ -497,6 +513,34 @@ def compile_simulation(request: SimulationRequest) -> CompiledProgram:
         )
         e_conductivity_x = e_conductivity_y = e_conductivity_z = empty3
         e_permittivity_x = e_permittivity_y = e_permittivity_z = empty3
+    empty_tensor = jnp.zeros((0,), dtype=jnp.float32)
+    if request.materials.uses_full_permittivity:
+        if any(
+            np.any(np.asarray(value) != 0.0)
+            for value in (fields.sig_x, fields.sig_y, fields.sig_z)
+        ):
+            raise ValueError(
+                "Full-tensor permittivity requires lossless electric updates; "
+                "use CPML rather than conductive or sponge-PML materials."
+            )
+        support_tensors = request.materials.yee_tensors
+        e_inverse_tensor_x = (
+            _inverse_permittivity_row(support_tensors["eps_x"], 0)
+            if "eps_x" in support_tensors
+            else empty_tensor
+        )
+        e_inverse_tensor_y = (
+            _inverse_permittivity_row(support_tensors["eps_y"], 1)
+            if "eps_y" in support_tensors
+            else empty_tensor
+        )
+        e_inverse_tensor_z = (
+            _inverse_permittivity_row(support_tensors["eps_z"], 2)
+            if "eps_z" in support_tensors
+            else empty_tensor
+        )
+    else:
+        e_inverse_tensor_x = e_inverse_tensor_y = e_inverse_tensor_z = empty_tensor
     # 5. Precompute the same packed recurrence record for every 2D or 3D derivative.
     cpml = _compile_cpml_plan(
         fields,
@@ -522,14 +566,17 @@ def compile_simulation(request: SimulationRequest) -> CompiledProgram:
         e_source_x=e_source_x,
         e_conductivity_x=e_conductivity_x,
         e_permittivity_x=e_permittivity_x,
+        e_inverse_tensor_x=e_inverse_tensor_x,
         e_decay_y=e_decay_y,
         e_source_y=e_source_y,
         e_conductivity_y=e_conductivity_y,
         e_permittivity_y=e_permittivity_y,
+        e_inverse_tensor_y=e_inverse_tensor_y,
         e_decay_z=e_decay_z,
         e_source_z=e_source_z,
         e_conductivity_z=e_conductivity_z,
         e_permittivity_z=e_permittivity_z,
+        e_inverse_tensor_z=e_inverse_tensor_z,
     )
     boundary = _compile_boundary(
         fields,
@@ -645,6 +692,9 @@ _REFERENCED_COEFFICIENTS = {
     "e_permittivity_x",
     "e_permittivity_y",
     "e_permittivity_z",
+    "e_inverse_tensor_x",
+    "e_inverse_tensor_y",
+    "e_inverse_tensor_z",
 }
 
 

--- a/beamz/simulation/kernels.py
+++ b/beamz/simulation/kernels.py
@@ -52,12 +52,20 @@ def fit_array_to_shape(arr, target_shape, *, pad_value=0.0):
 
 
 def collocate_yee_component(value, source: str, target: str, target_shape):
-    """Linearly collocate one electric-support array onto another Yee support."""
+    """Linearly collocate an electric or node-support array onto another support."""
 
     out = jnp.asarray(value)
     axes = ("z", "y", "x")[-out.ndim :]
-    source_offsets = component_axis_offsets_3d(source)
-    target_offsets = component_axis_offsets_3d(target)
+    source_offsets = (
+        {"z": 0.0, "y": 0.0, "x": 0.0}
+        if source == "Node"
+        else component_axis_offsets_3d(source)
+    )
+    target_offsets = (
+        {"z": 0.0, "y": 0.0, "x": 0.0}
+        if target == "Node"
+        else component_axis_offsets_3d(target)
+    )
     for axis_index, axis in enumerate(axes):
         source_offset = source_offsets[axis]
         target_offset = target_offsets[axis]
@@ -83,18 +91,37 @@ def collocate_yee_component(value, source: str, target: str, target_shape):
     return fit_array_to_shape(out, target_shape)
 
 
-def advance_e_full_tensor(fields, curls, inverse_rows, components, dt):
-    """Advance lossless electric fields through precomputed inverse tensor rows."""
+def advance_e_centered_tensor(
+    fields,
+    curls,
+    inverse_diagonals,
+    inverse_offdiagonal,
+    components,
+    dt,
+):
+    """Advance E with diagonal terms on E sites and cross terms on dual centers."""
 
     scale = jnp.asarray(dt, dtype=fields[0].dtype) / jnp.asarray(
         EPS_0, dtype=fields[0].dtype
     )
+    node_shape = inverse_offdiagonal.shape[:-1]
+    centered_curls = tuple(
+        collocate_yee_component(curl, source, "Node", node_shape)
+        for curl, source in zip(curls, components, strict=True)
+    )
+    cross_component = {(0, 1): 0, (0, 2): 1, (1, 2): 2}
     updated = []
-    for field, row, target in zip(fields, inverse_rows, components, strict=True):
-        coupled = jnp.zeros_like(field)
-        for column, (curl, source) in enumerate(zip(curls, components, strict=True)):
-            coupled = coupled + row[..., column] * collocate_yee_component(
-                curl, source, target, field.shape
+    for row, (field, diagonal, target) in enumerate(
+        zip(fields, inverse_diagonals, components, strict=True)
+    ):
+        coupled = diagonal * curls[row]
+        for column, centered_curl in enumerate(centered_curls):
+            if row == column:
+                continue
+            pair = (min(row, column), max(row, column))
+            centered = inverse_offdiagonal[..., cross_component[pair]] * centered_curl
+            coupled = coupled + collocate_yee_component(
+                centered, "Node", target, field.shape
             )
         updated.append(field + scale * coupled)
     return tuple(updated)
@@ -251,7 +278,8 @@ def fused_update_e_lossy_3d_material(
     resolution,
     *,
     boundary_views,
-    inverse_tensor_rows=None,
+    inverse_diagonals=None,
+    inverse_offdiagonal=None,
 ):
     """Advance all electric components directly from collocated material grids."""
     del hx, hy, hz
@@ -272,9 +300,14 @@ def fused_update_e_lossy_3d_material(
             field.shape,
         )
         curls.append(curl)
-    if inverse_tensor_rows is not None:
-        return advance_e_full_tensor(
-            (ex, ey, ez), curls, inverse_tensor_rows, ("Ex", "Ey", "Ez"), dt
+    if inverse_offdiagonal is not None:
+        return advance_e_centered_tensor(
+            (ex, ey, ez),
+            curls,
+            inverse_diagonals,
+            inverse_offdiagonal,
+            ("Ex", "Ey", "Ez"),
+            dt,
         )
     out = []
     for field, conductivity, inv_permittivity, curl in zip(
@@ -356,7 +389,8 @@ def cpml_update_e_from_h_3d(
     dt,
     conductivities,
     inverse_permittivities,
-    inverse_tensor_rows=None,
+    inverse_diagonals=None,
+    inverse_offdiagonal=None,
 ):
     """Advance 3D E fields and their six packed CPML memories."""
     views = build_h_boundary_views_for_e_3d(hx, hy, hz, metallic_edges)
@@ -384,9 +418,14 @@ def cpml_update_e_from_h_3d(
         strict=True,
     )
     curls = tuple(corrected[index] + corrected[index + 1] for index in (0, 2, 4))
-    if inverse_tensor_rows is not None:
-        updated = advance_e_full_tensor(
-            (ex, ey, ez), curls, inverse_tensor_rows, ("Ex", "Ey", "Ez"), dt
+    if inverse_offdiagonal is not None:
+        updated = advance_e_centered_tensor(
+            (ex, ey, ez),
+            curls,
+            inverse_diagonals,
+            inverse_offdiagonal,
+            ("Ex", "Ey", "Ez"),
+            dt,
         )
         return *updated, tuple(next_psi)
     one = jnp.asarray(1.0, dtype=ex.dtype)
@@ -683,13 +722,13 @@ def update_e_3d_cpml(eng, ctx, coeffs):
     inv_x = jnp.reciprocal(coeffs.e_permittivity_x)
     inv_y = jnp.reciprocal(coeffs.e_permittivity_y)
     inv_z = jnp.reciprocal(coeffs.e_permittivity_z)
-    inverse_tensor_rows = (
+    inverse_diagonals = (
         (
-            coeffs.e_inverse_tensor_x,
-            coeffs.e_inverse_tensor_y,
-            coeffs.e_inverse_tensor_z,
+            coeffs.e_inverse_diagonal_x,
+            coeffs.e_inverse_diagonal_y,
+            coeffs.e_inverse_diagonal_z,
         )
-        if coeffs.e_inverse_tensor_x.size
+        if coeffs.e_inverse_offdiagonal.size
         else None
     )
     # 2. Advance E while updating psi only inside the packed boundary slabs selected by
@@ -712,7 +751,10 @@ def update_e_3d_cpml(eng, ctx, coeffs):
             coeffs.e_conductivity_z,
         ),
         inverse_permittivities=(inv_x, inv_y, inv_z),
-        inverse_tensor_rows=inverse_tensor_rows,
+        inverse_diagonals=inverse_diagonals,
+        inverse_offdiagonal=(
+            coeffs.e_inverse_offdiagonal if coeffs.e_inverse_offdiagonal.size else None
+        ),
     )
     # 3. Replace E and packed 3D memory atomically, leaving unrelated carry fields intact.
     return _replace_e(
@@ -763,14 +805,17 @@ def update_e_3d_yee(eng, ctx, coeffs):
         ctx.dt_scalar,
         ctx.resolution,
         boundary_views=boundary_views,
-        inverse_tensor_rows=(
+        inverse_diagonals=(
             (
-                coeffs.e_inverse_tensor_x,
-                coeffs.e_inverse_tensor_y,
-                coeffs.e_inverse_tensor_z,
+                coeffs.e_inverse_diagonal_x,
+                coeffs.e_inverse_diagonal_y,
+                coeffs.e_inverse_diagonal_z,
             )
-            if coeffs.e_inverse_tensor_x.size
+            if coeffs.e_inverse_offdiagonal.size
             else None
+        ),
+        inverse_offdiagonal=(
+            coeffs.e_inverse_offdiagonal if coeffs.e_inverse_offdiagonal.size else None
         ),
     )
     return _replace_e(eng, ex, ey, ez)
@@ -876,11 +921,12 @@ def update_h_2d_te_xy_cpml(eng, ctx, coeffs):
 
 
 def _update_e_te_from_curls(eng, ctx, coeffs, curls, psi_e=None):
-    if coeffs.e_inverse_tensor_x.size:
-        ex, ey = advance_e_full_tensor(
+    if coeffs.e_inverse_offdiagonal.size:
+        ex, ey = advance_e_centered_tensor(
             (eng.ex, eng.ey),
             curls,
-            (coeffs.e_inverse_tensor_x, coeffs.e_inverse_tensor_y),
+            (coeffs.e_inverse_diagonal_x, coeffs.e_inverse_diagonal_y),
+            coeffs.e_inverse_offdiagonal,
             ("Ex", "Ey"),
             ctx.dt_scalar,
         )

--- a/beamz/simulation/kernels.py
+++ b/beamz/simulation/kernels.py
@@ -12,7 +12,7 @@ from beamz.const import EPS_0, MU_0
 from beamz.lattice import (
     adjacent_difference as _adjacent_difference,
 )
-from beamz.lattice import build_h_boundary_views_for_e_3d
+from beamz.lattice import build_h_boundary_views_for_e_3d, component_axis_offsets_3d
 from beamz.simulation.model import (
     BoundaryPlan,
     CpmlPackedSlabSpec,
@@ -49,6 +49,55 @@ def fit_array_to_shape(arr, target_shape, *, pad_value=0.0):
         if any(high for _, high in padding)
         else out
     )
+
+
+def collocate_yee_component(value, source: str, target: str, target_shape):
+    """Linearly collocate one electric-support array onto another Yee support."""
+
+    out = jnp.asarray(value)
+    axes = ("z", "y", "x")[-out.ndim :]
+    source_offsets = component_axis_offsets_3d(source)
+    target_offsets = component_axis_offsets_3d(target)
+    for axis_index, axis in enumerate(axes):
+        source_offset = source_offsets[axis]
+        target_offset = target_offsets[axis]
+        if source_offset == target_offset:
+            continue
+        if source_offset == 0.0 and target_offset == 0.5:
+            low = [slice(None)] * out.ndim
+            high = [slice(None)] * out.ndim
+            low[axis_index] = slice(0, -1)
+            high[axis_index] = slice(1, None)
+            out = 0.5 * (out[tuple(low)] + out[tuple(high)])
+        elif source_offset == 0.5 and target_offset == 0.0:
+            first = jnp.take(out, jnp.asarray([0]), axis=axis_index)
+            last = jnp.take(out, jnp.asarray([-1]), axis=axis_index)
+            low = [slice(None)] * out.ndim
+            high = [slice(None)] * out.ndim
+            low[axis_index] = slice(0, -1)
+            high[axis_index] = slice(1, None)
+            middle = 0.5 * (out[tuple(low)] + out[tuple(high)])
+            out = jnp.concatenate((first, middle, last), axis=axis_index)
+        else:  # pragma: no cover - canonical Yee offsets are binary
+            raise ValueError("Unsupported Yee colocation offset.")
+    return fit_array_to_shape(out, target_shape)
+
+
+def advance_e_full_tensor(fields, curls, inverse_rows, components, dt):
+    """Advance lossless electric fields through precomputed inverse tensor rows."""
+
+    scale = jnp.asarray(dt, dtype=fields[0].dtype) / jnp.asarray(
+        EPS_0, dtype=fields[0].dtype
+    )
+    updated = []
+    for field, row, target in zip(fields, inverse_rows, components, strict=True):
+        coupled = jnp.zeros_like(field)
+        for column, (curl, source) in enumerate(zip(curls, components, strict=True)):
+            coupled = coupled + row[..., column] * collocate_yee_component(
+                curl, source, target, field.shape
+            )
+        updated.append(field + scale * coupled)
+    return tuple(updated)
 
 
 def cpml_coefficients(sigma, kappa, alpha, dt):
@@ -202,6 +251,7 @@ def fused_update_e_lossy_3d_material(
     resolution,
     *,
     boundary_views,
+    inverse_tensor_rows=None,
 ):
     """Advance all electric components directly from collocated material grids."""
     del hx, hy, hz
@@ -212,16 +262,8 @@ def fused_update_e_lossy_3d_material(
         (("hx_z", 0), ("hz_x", 2)),
         (("hy_x", 2), ("hx_y", 1)),
     )
-    out = []
-    for field, conductivity, inv_permittivity, pair in zip(
-        (ex, ey, ez),
-        (conductivity_x, conductivity_y, conductivity_z),
-        (inv_permittivity_x, inv_permittivity_y, inv_permittivity_z),
-        derivative_pairs,
-        strict=True,
-    ):
-        beta = conductivity * (0.5 * dt_over_eps) * inv_permittivity
-        denom = one + beta
+    curls = []
+    for field, pair in zip((ex, ey, ez), derivative_pairs, strict=True):
         curl = fit_array_to_shape(
             _adjacent_difference(boundary_views[pair[0][0]], pair[0][1], resolution),
             field.shape,
@@ -229,6 +271,21 @@ def fused_update_e_lossy_3d_material(
             _adjacent_difference(boundary_views[pair[1][0]], pair[1][1], resolution),
             field.shape,
         )
+        curls.append(curl)
+    if inverse_tensor_rows is not None:
+        return advance_e_full_tensor(
+            (ex, ey, ez), curls, inverse_tensor_rows, ("Ex", "Ey", "Ez"), dt
+        )
+    out = []
+    for field, conductivity, inv_permittivity, curl in zip(
+        (ex, ey, ez),
+        (conductivity_x, conductivity_y, conductivity_z),
+        (inv_permittivity_x, inv_permittivity_y, inv_permittivity_z),
+        curls,
+        strict=True,
+    ):
+        beta = conductivity * (0.5 * dt_over_eps) * inv_permittivity
+        denom = one + beta
         out.append(
             (one - beta) / denom * field
             + (dt_over_eps * inv_permittivity / denom) * curl
@@ -299,6 +356,7 @@ def cpml_update_e_from_h_3d(
     dt,
     conductivities,
     inverse_permittivities,
+    inverse_tensor_rows=None,
 ):
     """Advance 3D E fields and their six packed CPML memories."""
     views = build_h_boundary_views_for_e_3d(hx, hy, hz, metallic_edges)
@@ -326,6 +384,11 @@ def cpml_update_e_from_h_3d(
         strict=True,
     )
     curls = tuple(corrected[index] + corrected[index + 1] for index in (0, 2, 4))
+    if inverse_tensor_rows is not None:
+        updated = advance_e_full_tensor(
+            (ex, ey, ez), curls, inverse_tensor_rows, ("Ex", "Ey", "Ez"), dt
+        )
+        return *updated, tuple(next_psi)
     one = jnp.asarray(1.0, dtype=ex.dtype)
     dt_over_eps = jnp.asarray(dt, dtype=ex.dtype) / jnp.asarray(EPS_0, dtype=ex.dtype)
     updated = []
@@ -620,6 +683,15 @@ def update_e_3d_cpml(eng, ctx, coeffs):
     inv_x = jnp.reciprocal(coeffs.e_permittivity_x)
     inv_y = jnp.reciprocal(coeffs.e_permittivity_y)
     inv_z = jnp.reciprocal(coeffs.e_permittivity_z)
+    inverse_tensor_rows = (
+        (
+            coeffs.e_inverse_tensor_x,
+            coeffs.e_inverse_tensor_y,
+            coeffs.e_inverse_tensor_z,
+        )
+        if coeffs.e_inverse_tensor_x.size
+        else None
+    )
     # 2. Advance E while updating psi only inside the packed boundary slabs selected by
     # the planner.
     ex, ey, ez, psi_e = cpml_update_e_from_h_3d(
@@ -640,6 +712,7 @@ def update_e_3d_cpml(eng, ctx, coeffs):
             coeffs.e_conductivity_z,
         ),
         inverse_permittivities=(inv_x, inv_y, inv_z),
+        inverse_tensor_rows=inverse_tensor_rows,
     )
     # 3. Replace E and packed 3D memory atomically, leaving unrelated carry fields intact.
     return _replace_e(
@@ -690,6 +763,15 @@ def update_e_3d_yee(eng, ctx, coeffs):
         ctx.dt_scalar,
         ctx.resolution,
         boundary_views=boundary_views,
+        inverse_tensor_rows=(
+            (
+                coeffs.e_inverse_tensor_x,
+                coeffs.e_inverse_tensor_y,
+                coeffs.e_inverse_tensor_z,
+            )
+            if coeffs.e_inverse_tensor_x.size
+            else None
+        ),
     )
     return _replace_e(eng, ex, ey, ez)
 
@@ -793,13 +875,22 @@ def update_h_2d_te_xy_cpml(eng, ctx, coeffs):
     return _update_h_te_from_curl(eng, coeffs, curl_hz, psi_h=psi_h)
 
 
-def _update_e_te_from_curls(eng, coeffs, curls, psi_e=None):
-    ex = advance_e_from_coefficients(
-        eng.ex, curls[0], coeffs.e_decay_x, coeffs.e_source_x
-    )
-    ey = advance_e_from_coefficients(
-        eng.ey, curls[1], coeffs.e_decay_y, coeffs.e_source_y
-    )
+def _update_e_te_from_curls(eng, ctx, coeffs, curls, psi_e=None):
+    if coeffs.e_inverse_tensor_x.size:
+        ex, ey = advance_e_full_tensor(
+            (eng.ex, eng.ey),
+            curls,
+            (coeffs.e_inverse_tensor_x, coeffs.e_inverse_tensor_y),
+            ("Ex", "Ey"),
+            ctx.dt_scalar,
+        )
+    else:
+        ex = advance_e_from_coefficients(
+            eng.ex, curls[0], coeffs.e_decay_x, coeffs.e_source_x
+        )
+        ey = advance_e_from_coefficients(
+            eng.ey, curls[1], coeffs.e_decay_y, coeffs.e_source_y
+        )
     return _replace_e(eng, ex, ey, eng.ez, cpml_e=psi_e)
 
 
@@ -811,7 +902,7 @@ def update_e_2d_te_xy(eng, ctx, coeffs):
         eng.ey.shape,
         ctx.boundary.metallic_edges_2d,
     )
-    return _update_e_te_from_curls(eng, coeffs, curls)
+    return _update_e_te_from_curls(eng, ctx, coeffs, curls)
 
 
 def update_e_2d_te_xy_cpml(eng, ctx, coeffs):
@@ -822,7 +913,7 @@ def update_e_2d_te_xy_cpml(eng, ctx, coeffs):
         terms=ctx.boundary.cpml.e_terms,
         psi_e_terms=eng.cpml_psi_e_terms,
     )
-    return _update_e_te_from_curls(eng, coeffs, curls, psi_e=psi_e)
+    return _update_e_te_from_curls(eng, ctx, coeffs, curls, psi_e=psi_e)
 
 
 @dataclass(frozen=True)

--- a/beamz/simulation/model.py
+++ b/beamz/simulation/model.py
@@ -268,14 +268,17 @@ class UpdateCoefficients(NamedTuple):
     e_source_x: jnp.ndarray
     e_conductivity_x: jnp.ndarray
     e_permittivity_x: jnp.ndarray
+    e_inverse_tensor_x: jnp.ndarray
     e_decay_y: jnp.ndarray
     e_source_y: jnp.ndarray
     e_conductivity_y: jnp.ndarray
     e_permittivity_y: jnp.ndarray
+    e_inverse_tensor_y: jnp.ndarray
     e_decay_z: jnp.ndarray
     e_source_z: jnp.ndarray
     e_conductivity_z: jnp.ndarray
     e_permittivity_z: jnp.ndarray
+    e_inverse_tensor_z: jnp.ndarray
 
 
 class CpmlPackedSlabSpec(NamedTuple):

--- a/beamz/simulation/model.py
+++ b/beamz/simulation/model.py
@@ -268,17 +268,18 @@ class UpdateCoefficients(NamedTuple):
     e_source_x: jnp.ndarray
     e_conductivity_x: jnp.ndarray
     e_permittivity_x: jnp.ndarray
-    e_inverse_tensor_x: jnp.ndarray
+    e_inverse_diagonal_x: jnp.ndarray
     e_decay_y: jnp.ndarray
     e_source_y: jnp.ndarray
     e_conductivity_y: jnp.ndarray
     e_permittivity_y: jnp.ndarray
-    e_inverse_tensor_y: jnp.ndarray
+    e_inverse_diagonal_y: jnp.ndarray
     e_decay_z: jnp.ndarray
     e_source_z: jnp.ndarray
     e_conductivity_z: jnp.ndarray
     e_permittivity_z: jnp.ndarray
-    e_inverse_tensor_z: jnp.ndarray
+    e_inverse_diagonal_z: jnp.ndarray
+    e_inverse_offdiagonal: jnp.ndarray
 
 
 class CpmlPackedSlabSpec(NamedTuple):

--- a/beamz/simulation/sharding.py
+++ b/beamz/simulation/sharding.py
@@ -265,9 +265,10 @@ _COEFFICIENT_COMPONENTS = {
             "source",
             "conductivity",
             "permittivity",
-            "inverse_tensor",
+            "inverse_diagonal",
         )
     },
+    "e_inverse_offdiagonal": "Node",
 }
 
 
@@ -280,13 +281,24 @@ def _lower_coefficients(coefficients, layout: ShardingLayout):
         value = getattr(coefficients, name)
         if _array_ndim(value) == 0 or not int(np.prod(_array_shape(value))):
             continue
-        is_tensor = "_inverse_tensor_" in name
+        is_tensor = name == "e_inverse_offdiagonal"
         neutral = (
             1.0
             if "_decay_" in name or ("_permittivity_" in name and not is_tensor)
             else 0.0
         )
-        target_shape = layout.padded_shapes[component]
+        target_shape = (
+            _pad_shape_for_devices(
+                tuple(
+                    max(shape[axis] for shape in layout.logical_shapes.values())
+                    for axis in range(len(next(iter(layout.logical_shapes.values()))))
+                ),
+                layout.axis,
+                layout.num_devices,
+            )
+            if component == "Node"
+            else layout.padded_shapes[component]
+        )
         if is_tensor:
             target_shape = (*target_shape, int(value.shape[-1]))
         updates[name] = _pad_high_to_shape(value, target_shape, pad_value=neutral)

--- a/beamz/simulation/sharding.py
+++ b/beamz/simulation/sharding.py
@@ -265,6 +265,7 @@ _COEFFICIENT_COMPONENTS = {
             "source",
             "conductivity",
             "permittivity",
+            "inverse_tensor",
         )
     },
 }
@@ -279,10 +280,16 @@ def _lower_coefficients(coefficients, layout: ShardingLayout):
         value = getattr(coefficients, name)
         if _array_ndim(value) == 0 or not int(np.prod(_array_shape(value))):
             continue
-        neutral = 1.0 if "_decay_" in name or "_permittivity_" in name else 0.0
-        updates[name] = _pad_high_to_shape(
-            value, layout.padded_shapes[component], pad_value=neutral
+        is_tensor = "_inverse_tensor_" in name
+        neutral = (
+            1.0
+            if "_decay_" in name or ("_permittivity_" in name and not is_tensor)
+            else 0.0
         )
+        target_shape = layout.padded_shapes[component]
+        if is_tensor:
+            target_shape = (*target_shape, int(value.shape[-1]))
+        updates[name] = _pad_high_to_shape(value, target_shape, pad_value=neutral)
     return coefficients._replace(**updates)
 
 

--- a/rust/fdtd-raster-core/src/grid.rs
+++ b/rust/fdtd-raster-core/src/grid.rs
@@ -19,6 +19,8 @@ impl SupportSpec {
         AxisLocation::Center,
         AxisLocation::Center,
     ]);
+    pub(crate) const NODE: Self =
+        Self::new([AxisLocation::Edge, AxisLocation::Edge, AxisLocation::Edge]);
     pub(crate) const EX: Self =
         Self::new([AxisLocation::Center, AxisLocation::Edge, AxisLocation::Edge]);
     pub(crate) const EY: Self =
@@ -221,6 +223,7 @@ mod tests {
         assert_eq!(SupportSpec::EX.logical_shape(&grid), [4, 4, 3]);
         assert_eq!(SupportSpec::EY.logical_shape(&grid), [5, 3, 3]);
         assert_eq!(SupportSpec::EZ.logical_shape(&grid), [5, 4, 2]);
+        assert_eq!(SupportSpec::NODE.logical_shape(&grid), [5, 4, 3]);
         let hx = SupportSpec::new([
             AxisLocation::Edge,
             AxisLocation::Center,

--- a/rust/fdtd-raster-core/src/raster.rs
+++ b/rust/fdtd-raster-core/src/raster.rs
@@ -119,6 +119,8 @@ pub struct DiagnosticSummary {
 pub struct RasterResult {
     /// Compact epsilon tensors at Ex, Ey, and Ez supports.
     pub epsilon: [TensorArray; 3],
+    /// Compact epsilon tensor on the dual-cell centers shared by cross terms.
+    pub node_epsilon: TensorArray,
     /// Compact mu tensors at Hx, Hy, and Hz supports.
     pub mu: [TensorArray; 3],
     /// Compact electric-conductivity tensors at Ex, Ey, and Ez supports.
@@ -139,6 +141,7 @@ enum Component {
     Hx,
     Hy,
     Hz,
+    Node,
     Cell,
 }
 
@@ -151,6 +154,7 @@ impl Component {
             Self::Hx => SupportSpec::HX,
             Self::Hy => SupportSpec::HY,
             Self::Hz => SupportSpec::HZ,
+            Self::Node => SupportSpec::NODE,
             Self::Cell => SupportSpec::CELL,
         }
     }
@@ -463,6 +467,21 @@ fn rasterize_impl(
             mu.push(omitted_tensor(component, grid));
         }
     }
+    let node_epsilon = if options.smoothing == SmoothingMode::FarjadpourFull
+        && options.output_components != OutputComponents::TwoDimensionalTm
+    {
+        let (shape, samples) =
+            raster_material_support(scene, &index, grid, options, Component::Node);
+        record_diagnostics(&mut diagnostics, &samples);
+        tensor_from_samples(
+            shape,
+            &samples,
+            |sample| sample.material.epsilon_r,
+            maximum_components,
+        )
+    } else {
+        omitted_tensor(Component::Node, grid)
+    };
     let (cell_epsilon, cell_mu, cell_conductivity) = if scalar_volume {
         let (cell_shape, cell_samples) =
             raster_scalar_support(scene, &index, grid, options, Component::Cell);
@@ -506,6 +525,7 @@ fn rasterize_impl(
     diagnostics.elapsed_seconds = start.elapsed().as_secs_f64();
     Ok(RasterResult {
         epsilon: epsilon.try_into().unwrap(),
+        node_epsilon,
         mu: mu.try_into().unwrap(),
         conductivity: conductivity.try_into().unwrap(),
         cell_epsilon,
@@ -1527,6 +1547,7 @@ mod tests {
         assert!(result.mu[0].values.is_empty());
         assert!(result.mu[1].values.is_empty());
         assert!(!result.mu[2].values.is_empty());
+        assert!(result.node_epsilon.values.is_empty());
         assert!(!result.cell_epsilon.values.is_empty());
     }
 
@@ -1579,7 +1600,7 @@ mod tests {
     }
 
     #[test]
-    fn full_tensors_are_integrated_independently_at_each_electric_support() {
+    fn full_tensors_are_integrated_independently_at_each_constitutive_support() {
         let polygon = Polygon2::new(vec![[-1.0, -1.0], [2.0, -1.0], [-1.0, 2.0]], vec![]).unwrap();
         let geometry =
             Geometry::ExtrudedPolygon(crate::ExtrudedPolygon::new(polygon, -1.0, 2.0).unwrap());
@@ -1607,9 +1628,9 @@ mod tests {
         };
         let result = rasterize(&scene, &grid, &options).unwrap();
 
-        for (component, tensor) in [Component::Ex, Component::Ey, Component::Ez]
+        for (component, tensor) in [Component::Ex, Component::Ey, Component::Ez, Component::Node]
             .into_iter()
-            .zip(&result.epsilon)
+            .zip(result.epsilon.iter().chain([&result.node_epsilon]))
         {
             assert_eq!(tensor.shape[0], 6);
             let logical_shape = component.support().logical_shape(&grid);

--- a/rust/fdtd-raster-py/src/lib.rs
+++ b/rust/fdtd-raster-py/src/lib.rs
@@ -61,6 +61,7 @@ impl NativeRasterResult {
         {
             insert_tensor(py, &arrays, name, tensor)?;
         }
+        insert_tensor(py, &arrays, "epsilon_node", &mut self.result.node_epsilon)?;
         for (name, tensor) in ["mu_hx", "mu_hy", "mu_hz"]
             .into_iter()
             .zip(&mut self.result.mu)

--- a/tests/integration/test_mode_launch_planner.py
+++ b/tests/integration/test_mode_launch_planner.py
@@ -62,6 +62,20 @@ def _direct_yee_2d_fields(shape, *, resolution=1.0):
     return fields
 
 
+def _full_tensor_2d_fields(shape, *, resolution=1.0):
+    fields = _direct_yee_2d_fields(shape, resolution=resolution)
+    support_shape = fields.material_grid.yee_materials["eps_z"].shape
+    tensor = np.zeros((6, *support_shape), dtype=np.float32)
+    tensor[:3] = 2.25
+    tensor[3] = 0.1
+    fields.material_grid = replace(
+        fields.material_grid,
+        yee_tensors={"eps_z": tensor},
+        smoothing="farjadpour_full",
+    )
+    return fields
+
+
 def _mode_source(**overrides):
     source_time = overrides.pop(
         "source_time", GaussianPulse(freq0=2.0e14, fwidth=2.0e13)
@@ -228,11 +242,11 @@ def test_mode_launch_rejects_conductive_material_profile():
         plan_mode_source_launch(_mode_source(), fields, resolution=1.0, dt=1e-15)
 
 
-def test_2d_mode_launch_rejects_materials_requiring_direct_yee_supports():
-    fields = _direct_yee_2d_fields((5, 6))
+def test_2d_mode_launch_rejects_full_off_diagonal_materials():
+    fields = _full_tensor_2d_fields((5, 6))
     source = _mode_source(mode_spec=ModeSpec(polarization="tm"))
 
-    with pytest.raises(ValueError, match="direct Yee-support"):
+    with pytest.raises(ValueError, match="full off-diagonal"):
         plan_mode_source_launch(source, fields, resolution=1.0, dt=1e-15)
 
 
@@ -281,8 +295,8 @@ def test_2d_mode_source_rejects_polarization_mismatch():
         plan_mode_source_launch(source, fields, resolution=1.0, dt=1e-15)
 
 
-def test_public_mode_solve_rejects_materials_requiring_direct_yee_supports():
-    fields = _direct_yee_2d_fields((5, 6))
+def test_public_mode_solve_rejects_full_off_diagonal_materials():
+    fields = _full_tensor_2d_fields((5, 6))
     simulation = SimpleNamespace(fields=fields, resolution=1.0)
     plane = SimpleNamespace(
         center=(2.5, 2.5, 2.5),
@@ -290,7 +304,7 @@ def test_public_mode_solve_rejects_materials_requiring_direct_yee_supports():
         axis="x",
     )
 
-    with pytest.raises(ValueError, match="direct Yee-support"):
+    with pytest.raises(ValueError, match="full off-diagonal"):
         mode_plane_context(simulation=simulation, plane=plane)
 
 

--- a/tests/integration/test_native_design_rasterization.py
+++ b/tests/integration/test_native_design_rasterization.py
@@ -433,7 +433,7 @@ def test_material_grid_simulation_rejects_conflicting_geometry_controls(
         bz.Simulation(material_grid=material_grid, run_time=2e-9, **kwargs)
 
 
-def test_full_tensor_and_full_farjadpour_compile_into_inverse_rows():
+def test_full_tensor_and_full_farjadpour_compile_onto_constitutive_supports():
     tensor_scene = Scene(
         (Material(epsilon_r=((3.0, 0.2, 0.0), (0.2, 2.0, 0.0), (0.0, 0.0, 1.0))),)
     )
@@ -475,9 +475,10 @@ def test_full_tensor_and_full_farjadpour_compile_into_inverse_rows():
 
     assert material_grid.uses_full_permittivity
     assert program.boundary.cpml.enabled
-    assert program.coefficients.e_inverse_tensor_x.shape == (3, 3, 2, 3)
-    assert program.coefficients.e_inverse_tensor_y.shape == (3, 2, 3, 3)
-    assert program.coefficients.e_inverse_tensor_z.shape == (2, 3, 3, 3)
+    assert program.coefficients.e_inverse_diagonal_x.shape == (3, 3, 2)
+    assert program.coefficients.e_inverse_diagonal_y.shape == (3, 2, 3)
+    assert program.coefficients.e_inverse_diagonal_z.shape == (2, 3, 3)
+    assert program.coefficients.e_inverse_offdiagonal.shape == (3, 3, 3, 3)
     assert all(np.all(np.isfinite(getattr(state, name))) for name in ("ex", "ey", "ez"))
 
     logical_shapes = program.sharding.layout.logical_shapes
@@ -488,7 +489,8 @@ def test_full_tensor_and_full_farjadpour_compile_into_inverse_rows():
         program.coefficients,
         ShardingLayout(True, "z", 0, 2, "cpu", logical_shapes, padded_shapes),
     )
-    assert lowered.e_inverse_tensor_x.shape == (*padded_shapes["Ex"], 3)
+    assert lowered.e_inverse_diagonal_x.shape == padded_shapes["Ex"]
+    assert lowered.e_inverse_offdiagonal.shape == (4, 3, 3, 3)
 
     with pytest.raises(ValueError, match="use CPML"):
         bz.Simulation(

--- a/tests/integration/test_native_design_rasterization.py
+++ b/tests/integration/test_native_design_rasterization.py
@@ -5,7 +5,18 @@ import pytest
 
 import beamz as bz
 from beamz.design import MaterialGrid
-from beamz.design.raster import Grid, Material, RasterOptions, Scene, rasterize
+from beamz.design.raster import (
+    ExtrudedPolygon,
+    Grid,
+    Material,
+    Object,
+    Polygon,
+    RasterOptions,
+    Scene,
+    rasterize,
+)
+from beamz.simulation.model import ShardingLayout
+from beamz.simulation.sharding import _lower_coefficients
 
 
 def design_2d() -> bz.Design:
@@ -61,6 +72,27 @@ def test_material_grid_rejects_nonpositive_resolution():
         MaterialGrid(values, values, values, 0.0, values.shape)
 
 
+@pytest.mark.parametrize(
+    ("yee_tensors", "message"),
+    (
+        ({"unknown": np.ones((6, 2, 2))}, "Unknown Yee permittivity tensors"),
+        ({"eps_x": np.ones((2, 3, 2))}, "expected compact"),
+    ),
+)
+def test_material_grid_validates_full_yee_tensor_contract(yee_tensors, message):
+    values = np.ones((2, 2))
+
+    with pytest.raises(ValueError, match=message):
+        MaterialGrid(
+            values,
+            values,
+            values,
+            1.0,
+            values.shape,
+            yee_tensors=yee_tensors,
+        )
+
+
 def test_design_rasterize_returns_direct_3d_solver_grid():
     grid = design_3d().rasterize(0.25e-6)
 
@@ -83,7 +115,7 @@ def test_design_tensor_material_uses_same_native_path_as_imported_scene():
 
 
 @pytest.mark.parametrize("design", [design_2d(), design_3d()])
-def test_default_scalar_volume_compilation_preserves_cell_colocation(design):
+def test_default_farjadpour_compilation_preserves_native_colocation(design):
     material_grid = design.rasterize(0.25e-6)
     simulation = bz.Simulation(
         design=design,
@@ -94,7 +126,8 @@ def test_default_scalar_volume_compilation_preserves_cell_colocation(design):
 
     np.testing.assert_array_equal(compiled.permittivity, material_grid.permittivity)
     np.testing.assert_array_equal(compiled.permeability, material_grid.permeability)
-    assert not material_grid.uses_direct_yee_materials
+    assert material_grid.smoothing == "farjadpour_diagonal"
+    assert material_grid.uses_direct_yee_materials
 
 
 def test_simulation_conversion_rejects_nonunit_permeability():
@@ -105,6 +138,32 @@ def test_simulation_conversion_rejects_nonunit_permeability():
 
     with pytest.raises(ValueError, match="unit permeability"):
         MaterialGrid.from_raster_result(result)
+
+
+@pytest.mark.parametrize(
+    ("epsilon", "conductivity", "dimensions", "message"),
+    (
+        (
+            (3.0, 2.0, 1.5),
+            (1.0, 0.5, 0.2, 0.1, 0.0, 0.0),
+            3,
+            "off-diagonal conductivity",
+        ),
+        ((3.0, 2.0, 1.5, 0.0, 0.1, 0.0), 0.0, 2, "without xz or yz"),
+        ((3.0, 2.0, 1.5, 0.2, 0.0, 0.0), (1.0, 0.5, 0.2), 3, "zero conductivity"),
+    ),
+)
+def test_full_tensor_conversion_rejects_unsupported_material_couplings(
+    epsilon, conductivity, dimensions, message
+):
+    shape = (2, 2, 2 if dimensions == 3 else 1)
+    result = rasterize(
+        Scene((Material(epsilon_r=epsilon, conductivity=conductivity),)),
+        Grid.uniform((0, 0, 0), (1, 1, 1), shape),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        MaterialGrid.from_raster_result(result, dimensions=dimensions)
 
 
 def test_material_grid_rejects_nonuniform_raster_results():
@@ -374,21 +433,69 @@ def test_material_grid_simulation_rejects_conflicting_geometry_controls(
         bz.Simulation(material_grid=material_grid, run_time=2e-9, **kwargs)
 
 
-def test_full_tensor_and_full_farjadpour_require_future_engine():
+def test_full_tensor_and_full_farjadpour_compile_into_inverse_rows():
     tensor_scene = Scene(
         (Material(epsilon_r=((3.0, 0.2, 0.0), (0.2, 2.0, 0.0), (0.0, 0.0, 1.0))),)
     )
     grid = Grid.uniform((0, 0, 0), (1, 1, 1), (2, 2, 2))
-    with pytest.raises(ValueError, match="silently discard"):
-        MaterialGrid.from_raster_result(rasterize(tensor_scene, grid))
+    intrinsic = MaterialGrid.from_raster_result(
+        rasterize(
+            tensor_scene,
+            grid,
+            options=RasterOptions(smoothing="farjadpour_full"),
+        )
+    )
+    assert intrinsic.uses_full_permittivity
 
     full = rasterize(
-        Scene((Material(),)),
+        Scene(
+            (Material(), Material(4.0)),
+            (
+                Object(
+                    ExtrudedPolygon(
+                        Polygon(((-1.0, -1.0), (2.0, -1.0), (-1.0, 2.0))),
+                        -1.0,
+                        2.0,
+                    ),
+                    1,
+                ),
+            ),
+        ),
         grid,
         options=RasterOptions(smoothing="farjadpour_full"),
     )
-    with pytest.raises(ValueError, match="full off-diagonal Farjadpour"):
-        MaterialGrid.from_raster_result(full)
+    material_grid = MaterialGrid.from_raster_result(full)
+    simulation = bz.Simulation(
+        material_grid=material_grid,
+        boundaries=[bz.PML(thickness=0.5, formulation="cpml")],
+        run_time=2e-9,
+    )
+    program = simulation.compile()
+    state = simulation.advance().state
+
+    assert material_grid.uses_full_permittivity
+    assert program.boundary.cpml.enabled
+    assert program.coefficients.e_inverse_tensor_x.shape == (3, 3, 2, 3)
+    assert program.coefficients.e_inverse_tensor_y.shape == (3, 2, 3, 3)
+    assert program.coefficients.e_inverse_tensor_z.shape == (2, 3, 3, 3)
+    assert all(np.all(np.isfinite(getattr(state, name))) for name in ("ex", "ey", "ez"))
+
+    logical_shapes = program.sharding.layout.logical_shapes
+    padded_shapes = {
+        name: (shape[0] + 1, *shape[1:]) for name, shape in logical_shapes.items()
+    }
+    lowered = _lower_coefficients(
+        program.coefficients,
+        ShardingLayout(True, "z", 0, 2, "cpu", logical_shapes, padded_shapes),
+    )
+    assert lowered.e_inverse_tensor_x.shape == (*padded_shapes["Ex"], 3)
+
+    with pytest.raises(ValueError, match="use CPML"):
+        bz.Simulation(
+            material_grid=material_grid,
+            boundaries=[bz.PML(thickness=0.5, formulation="sponge")],
+            run_time=2e-9,
+        ).compile()
 
 
 def test_simulation_selects_explicit_diagonal_farjadpour_policy():

--- a/tests/integration/test_te_simulation.py
+++ b/tests/integration/test_te_simulation.py
@@ -5,6 +5,7 @@ import pytest
 
 import beamz as bz
 from beamz.const import LIGHT_SPEED
+from beamz.design import raster
 
 
 def _te_simulation(*, cpml: bool = False):
@@ -131,3 +132,58 @@ def test_te_simulation_rejects_tm_mode_monitor():
 
     with pytest.raises(ValueError, match="does not match"):
         simulation.compile()
+
+
+def test_te_simulation_can_select_full_or_diagonal_farjadpour_updates():
+    length = 1.0 * bz.um
+    cells = 8
+    resolution = length / cells
+    dt = 0.2 * resolution / LIGHT_SPEED
+    time = np.arange(10) * dt
+    scene = raster.Scene(
+        (raster.Material(), raster.Material(4.0)),
+        (
+            raster.Object(
+                raster.ExtrudedPolygon(
+                    raster.Polygon(
+                        (
+                            (-length, -length),
+                            (2 * length, -length),
+                            (-length, 2 * length),
+                        )
+                    ),
+                    0.0,
+                    1.0,
+                ),
+                1,
+            ),
+        ),
+    )
+    grid = raster.Grid.uniform(
+        (0.0, 0.0, 0.0), (length, length, 1.0), (cells, cells, 1)
+    )
+
+    def run(smoothing):
+        simulation = bz.Simulation(
+            scene=scene,
+            raster_grid=grid,
+            polarization="te",
+            time=time,
+            raster_options=raster.RasterOptions(smoothing=smoothing),
+            sources=(
+                bz.GaussianSource(
+                    position=(0.3 * bz.um, 0.35 * bz.um),
+                    width=0.1 * bz.um,
+                    signal=np.r_[1.0, np.zeros(time.size - 1)],
+                ),
+            ),
+        )
+        return simulation.compile(), np.asarray(simulation.advance().state.hz)
+
+    full_program, full_hz = run("farjadpour_full")
+    diagonal_program, diagonal_hz = run("farjadpour_diagonal")
+
+    assert full_program.coefficients.e_inverse_tensor_x.size > 0
+    assert diagonal_program.coefficients.e_inverse_tensor_x.size == 0
+    assert np.all(np.isfinite(full_hz))
+    assert np.linalg.norm(full_hz - diagonal_hz) > 0.01 * np.linalg.norm(full_hz)

--- a/tests/integration/test_te_simulation.py
+++ b/tests/integration/test_te_simulation.py
@@ -183,7 +183,7 @@ def test_te_simulation_can_select_full_or_diagonal_farjadpour_updates():
     full_program, full_hz = run("farjadpour_full")
     diagonal_program, diagonal_hz = run("farjadpour_diagonal")
 
-    assert full_program.coefficients.e_inverse_tensor_x.size > 0
-    assert diagonal_program.coefficients.e_inverse_tensor_x.size == 0
+    assert full_program.coefficients.e_inverse_offdiagonal.size > 0
+    assert diagonal_program.coefficients.e_inverse_offdiagonal.size == 0
     assert np.all(np.isfinite(full_hz))
     assert np.linalg.norm(full_hz - diagonal_hz) > 0.01 * np.linalg.norm(full_hz)

--- a/tests/unit/raster/test_api.py
+++ b/tests/unit/raster/test_api.py
@@ -28,13 +28,13 @@ def test_uniform_result_uses_solver_facing_yee_shapes():
         box_scene(), raster.Grid.uniform((0, 0, 0), (1, 1, 1), (2, 3, 4))
     )
 
-    assert result.tensors["epsilon"].shape == (1, 4, 3, 2)
-    assert result.yee_tensors["epsilon_ex"].shape == (1, 5, 4, 2)
-    assert result.yee_tensors["epsilon_ey"].shape == (1, 5, 3, 3)
-    assert result.yee_tensors["epsilon_ez"].shape == (1, 4, 4, 3)
-    assert result.yee_tensors["mu_hx"].shape == (1, 4, 3, 3)
-    assert result.yee_tensors["mu_hy"].shape == (1, 4, 4, 2)
-    assert result.yee_tensors["mu_hz"].shape == (1, 5, 3, 2)
+    assert result.tensors["epsilon"].shape == (3, 4, 3, 2)
+    assert result.yee_tensors["epsilon_ex"].shape == (3, 5, 4, 2)
+    assert result.yee_tensors["epsilon_ey"].shape[1:] == (5, 3, 3)
+    assert result.yee_tensors["epsilon_ez"].shape[1:] == (4, 4, 3)
+    assert result.yee_tensors["mu_hx"].shape[1:] == (4, 3, 3)
+    assert result.yee_tensors["mu_hy"].shape[1:] == (4, 4, 2)
+    assert result.yee_tensors["mu_hz"].shape[1:] == (5, 3, 2)
 
 
 def test_scene_has_design_like_rasterize_convenience():
@@ -60,7 +60,7 @@ def test_nonuniform_grid_is_supported_and_immutable():
 
     assert not grid.is_uniform
     assert not result.is_uniform
-    assert result.tensors["epsilon"].shape == (1, 1, 2, 2)
+    assert result.tensors["epsilon"].shape == (3, 1, 2, 2)
     with pytest.raises(ValueError):
         result.tensors["epsilon"][0, 0, 0, 0] = 9
     with pytest.raises(ValueError):
@@ -84,7 +84,7 @@ def test_two_dimensional_tm_omits_unused_components():
         "mu_hx",
         "mu_hy",
     }
-    assert result.tensors["epsilon"].shape == (1, 1, 2, 2)
+    assert result.tensors["epsilon"].shape == (3, 1, 2, 2)
 
 
 def test_two_dimensional_te_omits_unused_components():
@@ -101,7 +101,7 @@ def test_two_dimensional_te_omits_unused_components():
         "conductivity_ey",
         "mu_hz",
     }
-    assert result.tensors["epsilon"].shape == (1, 1, 2, 2)
+    assert result.tensors["epsilon"].shape == (3, 1, 2, 2)
 
 
 def test_compiled_scene_reuse_and_cache_recovery(tmp_path):
@@ -167,6 +167,7 @@ def test_scene_hash_and_cache_include_materials_and_nonuniform_edges(tmp_path):
 
 
 def test_invalid_public_options_fail_early():
+    assert raster.RasterOptions().smoothing == "farjadpour_full"
     with pytest.raises(ValueError, match="quality"):
         raster.RasterOptions(quality="custom")
     with pytest.raises(ValueError, match="smoothing"):

--- a/tests/unit/raster/test_api.py
+++ b/tests/unit/raster/test_api.py
@@ -32,6 +32,7 @@ def test_uniform_result_uses_solver_facing_yee_shapes():
     assert result.yee_tensors["epsilon_ex"].shape == (3, 5, 4, 2)
     assert result.yee_tensors["epsilon_ey"].shape[1:] == (5, 3, 3)
     assert result.yee_tensors["epsilon_ez"].shape[1:] == (4, 4, 3)
+    assert result.yee_tensors["epsilon_node"].shape[1:] == (5, 4, 3)
     assert result.yee_tensors["mu_hx"].shape[1:] == (4, 3, 3)
     assert result.yee_tensors["mu_hy"].shape[1:] == (4, 4, 2)
     assert result.yee_tensors["mu_hz"].shape[1:] == (5, 3, 2)
@@ -97,6 +98,7 @@ def test_two_dimensional_te_omits_unused_components():
     assert set(result.yee_tensors) == {
         "epsilon_ex",
         "epsilon_ey",
+        "epsilon_node",
         "conductivity_ex",
         "conductivity_ey",
         "mu_hz",
@@ -229,7 +231,7 @@ def test_diagonal_material_uses_three_component_tensor_storage():
     np.testing.assert_array_equal(result.tensors["epsilon"][:, 0, 0, 0], (2, 3, 4))
 
 
-def test_intrinsic_full_tensors_are_retained_at_their_field_supports():
+def test_intrinsic_full_tensors_are_retained_at_their_constitutive_supports():
     epsilon = (3.0, 2.0, 1.5, 0.2, 0.0, 0.1)
     mu = (2.0, 1.5, 1.2, 0.1, 0.0, 0.0)
     conductivity = (1.0, 0.5, 0.2, 0.1, 0.0, 0.0)
@@ -238,7 +240,7 @@ def test_intrinsic_full_tensors_are_retained_at_their_field_supports():
         raster.Grid.uniform((0, 0, 0), (1, 1, 1), (2, 3, 4)),
     )
 
-    for name in ("epsilon_ex", "epsilon_ey", "epsilon_ez"):
+    for name in ("epsilon_ex", "epsilon_ey", "epsilon_ez", "epsilon_node"):
         values = result.yee_tensors[name]
         assert values.shape[0] == 6
         np.testing.assert_allclose(values[:, 0, 0, 0], epsilon)

--- a/tests/validation/convergence/test_full_tensor_fdtd_convergence.py
+++ b/tests/validation/convergence/test_full_tensor_fdtd_convergence.py
@@ -10,7 +10,7 @@ import numpy as np
 from beamz.const import EPS_0, LIGHT_SPEED, MU_0
 from beamz.lattice import advance_h_field
 from beamz.simulation.kernels import (
-    advance_e_full_tensor,
+    advance_e_centered_tensor,
     te_xy_curl_e_to_h_2d,
     te_xy_curl_h_to_e_2d,
 )
@@ -44,24 +44,12 @@ def _anisotropic_packet_displacement(cells: int) -> float:
         dtype=jnp.float32,
     )
     hz = jnp.asarray(np.tile(packet(x_h) / impedance, (4, 1)), dtype=jnp.float32)
-    rows = (
-        jnp.stack(
-            (
-                jnp.full_like(ex, inverse[0, 0]),
-                jnp.full_like(ex, inverse[0, 1]),
-                jnp.zeros_like(ex),
-            ),
-            axis=-1,
-        ),
-        jnp.stack(
-            (
-                jnp.full_like(ey, inverse[1, 0]),
-                jnp.full_like(ey, inverse[1, 1]),
-                jnp.zeros_like(ey),
-            ),
-            axis=-1,
-        ),
+    diagonals = (
+        jnp.full_like(ex, inverse[0, 0]),
+        jnp.full_like(ey, inverse[1, 1]),
     )
+    offdiagonal = jnp.zeros((5, cells + 1, 3), dtype=jnp.float32)
+    offdiagonal = offdiagonal.at[..., 0].set(inverse[0, 1])
     start = _centroid(hz, spacing)
     duration = 30e-15
     steps = round(duration / (0.2 * spacing / LIGHT_SPEED))
@@ -70,7 +58,9 @@ def _anisotropic_packet_displacement(cells: int) -> float:
         curl_hz = te_xy_curl_e_to_h_2d(ex, ey, spacing, hz.shape)
         hz = advance_h_field(hz, curl_hz, 0.0, dt)
         curls = te_xy_curl_h_to_e_2d(hz, spacing, ex.shape, ey.shape, frozenset())
-        ex, ey = advance_e_full_tensor((ex, ey), curls, rows, ("Ex", "Ey"), dt)
+        ex, ey = advance_e_centered_tensor(
+            (ex, ey), curls, diagonals, offdiagonal, ("Ex", "Ey"), dt
+        )
     return _centroid(hz, spacing) - start
 
 

--- a/tests/validation/convergence/test_full_tensor_fdtd_convergence.py
+++ b/tests/validation/convergence/test_full_tensor_fdtd_convergence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from functools import cache
 
 import jax.numpy as jnp
 import numpy as np
@@ -119,33 +120,347 @@ def _sloped_interface_simulation(cells: int, time: np.ndarray):
     return simulation, state
 
 
-def _sloped_interface_probe(cells: int) -> float:
-    length = 4.0 * bz.um
+def _yee_coordinates(component: str, shape, spacing: float):
+    y_offset, x_offset = {
+        "Ex": (0.0, 0.5),
+        "Ey": (0.5, 0.0),
+        "Hz": (0.5, 0.5),
+    }[component]
+    y = (np.arange(shape[0]) + y_offset) * spacing
+    x = (np.arange(shape[1]) + x_offset) * spacing
+    return np.meshgrid(y, x, indexing="ij")
+
+
+def _exact_normal_pulse(
+    component: str,
+    y,
+    x,
+    time: float,
+    *,
+    normal,
+    interface_coordinate: float,
+):
+    """Return the exact normally incident TE pulse on one Yee component."""
+
+    epsilon_left, epsilon_right = 1.0, 4.0
+    index_left, index_right = np.sqrt((epsilon_left, epsilon_right))
+    speed_left = LIGHT_SPEED / index_left
+    impedance_left = np.sqrt(MU_0 / (EPS_0 * epsilon_left))
+    impedance_right = np.sqrt(MU_0 / (EPS_0 * epsilon_right))
+    reflection = (index_left - index_right) / (index_left + index_right)
+    transmission = 2.0 * index_left / (index_left + index_right)
+    pulse_center = interface_coordinate - 0.9 * bz.um
+    pulse_width = 0.3 * bz.um
+    wavelength = 1.2 * bz.um
+
+    def profile(coordinate):
+        relative = coordinate - pulse_center
+        return np.exp(-0.5 * (relative / pulse_width) ** 2) * np.cos(
+            2.0 * np.pi * relative / wavelength
+        )
+
+    coordinate = normal[0] * x + normal[1] * y
+    incident = profile(coordinate - speed_left * time)
+    reflected = profile(2.0 * interface_coordinate - coordinate - speed_left * time)
+    transmitted = profile(
+        interface_coordinate
+        + (index_right / index_left) * (coordinate - interface_coordinate)
+        - speed_left * time
+    )
+    left = coordinate <= interface_coordinate
+    electric = np.where(
+        left,
+        incident + reflection * reflected,
+        transmission * transmitted,
+    )
+    magnetic = np.where(
+        left,
+        (incident - reflection * reflected) / impedance_left,
+        transmission * transmitted / impedance_right,
+    )
+    tangent = (-normal[1], normal[0])
+    return {"Ex": tangent[0] * electric, "Ey": tangent[1] * electric, "Hz": magnetic}[
+        component
+    ]
+
+
+@cache
+def _analytical_interface_error(
+    cells: int,
+    *,
+    smoothing="farjadpour_full",
+    interface_offset=0.07 * bz.um,
+    angle_degrees=27.0,
+    anisotropic=True,
+) -> float:
+    """Run the public raster-to-FDTD path and return its global exact-solution error."""
+
+    length = 8.0 * bz.um
     spacing = length / cells
+    angle = np.deg2rad(angle_degrees)
+    normal = np.asarray((np.cos(angle), np.sin(angle)))
+    tangent = np.asarray((-normal[1], normal[0]))
+    # The right material's principal axes follow the interface. Normal incidence with
+    # tangential E therefore sees epsilon=4 exactly, while epsilon=6 still exercises
+    # intrinsic Cartesian off-diagonal coupling after rotation.
+    epsilon_right_xy = (
+        6.0 * np.outer(normal, normal) + 4.0 * np.outer(tangent, tangent)
+        if anisotropic
+        else 4.0 * np.eye(2)
+    )
+    epsilon_right = (
+        (epsilon_right_xy[0, 0], epsilon_right_xy[0, 1], 0.0),
+        (epsilon_right_xy[1, 0], epsilon_right_xy[1, 1], 0.0),
+        (0.0, 0.0, 3.0),
+    )
+    interface_point = (
+        np.asarray((0.5 * length, 0.5 * length)) + interface_offset * normal
+    )
+    interface_coordinate = float(normal @ interface_point)
+    extent = 3.0 * length
+    polygon = tuple(
+        map(
+            tuple,
+            (
+                interface_point - extent * tangent,
+                interface_point + extent * tangent,
+                interface_point + extent * tangent + extent * normal,
+                interface_point - extent * tangent + extent * normal,
+            ),
+        )
+    )
     steps = cells
-    duration = 3.0e-15
-    simulation, state = _sloped_interface_simulation(
-        cells, np.arange(steps) * (duration / steps)
+    dt = 0.2 * spacing / LIGHT_SPEED
+    simulation = bz.Simulation(
+        scene=raster.Scene(
+            (
+                raster.Material(),
+                raster.Material(epsilon_right if anisotropic else 4.0),
+            ),
+            (
+                raster.Object(
+                    raster.ExtrudedPolygon(raster.Polygon(polygon), 0.0, 1.0),
+                    1,
+                ),
+            ),
+        ),
+        raster_grid=raster.Grid.uniform(
+            (0.0, 0.0, 0.0), (length, length, 1.0), (cells, cells, 1)
+        ),
+        polarization="te",
+        time=np.arange(steps) * dt,
+        sources=(),
+        normalize_source=None,
+        raster_options=raster.RasterOptions(smoothing=smoothing),
     )
-    coordinates = (np.arange(cells) + 0.5) * spacing
-    y, x = np.meshgrid(coordinates, coordinates, indexing="ij")
-    final_hz = np.asarray(
-        simulation.advance(state=state, progress=False).state.hz,
-        dtype=np.float64,
+    state = simulation.initial_state()
+    initial = {}
+    for component, field, time in (
+        ("Ex", state.ex, 0.0),
+        ("Ey", state.ey, 0.0),
+        ("Hz", state.hz, -0.5 * dt),
+    ):
+        y, x = _yee_coordinates(component, field.shape, spacing)
+        initial[component] = jnp.asarray(
+            _exact_normal_pulse(
+                component,
+                y,
+                x,
+                time,
+                normal=normal,
+                interface_coordinate=interface_coordinate,
+            ),
+            dtype=field.dtype,
+        )
+    state = state._replace(ex=initial["Ex"], ey=initial["Ey"], hz=initial["Hz"])
+    final = simulation.advance(state=state, progress=False).state
+
+    ex = 0.5 * (np.asarray(final.ex[:-1]) + np.asarray(final.ex[1:]))
+    ey = 0.5 * (np.asarray(final.ey[:, :-1]) + np.asarray(final.ey[:, 1:]))
+    hz = np.asarray(final.hz)
+    y, x = _yee_coordinates("Hz", hz.shape, spacing)
+    exact_ex = _exact_normal_pulse(
+        "Ex",
+        y,
+        x,
+        steps * dt,
+        normal=normal,
+        interface_coordinate=interface_coordinate,
     )
-    probe = np.exp(
-        -((x - 2.1 * bz.um) ** 2 + (y - 2.1 * bz.um) ** 2) / (2.0 * (0.35 * bz.um) ** 2)
+    exact_ey = _exact_normal_pulse(
+        "Ey",
+        y,
+        x,
+        steps * dt,
+        normal=normal,
+        interface_coordinate=interface_coordinate,
     )
-    return float(spacing**2 * np.sum(probe * final_hz**2))
+    exact_hz = _exact_normal_pulse(
+        "Hz",
+        y,
+        x,
+        (steps - 0.5) * dt,
+        normal=normal,
+        interface_coordinate=interface_coordinate,
+    )
+    coordinate = normal[0] * x + normal[1] * y
+    epsilon = np.where(
+        (coordinate <= interface_coordinate)[..., None, None],
+        np.eye(2),
+        epsilon_right_xy,
+    )
+    electric_error = np.stack((ex - exact_ex, ey - exact_ey), axis=-1)
+    exact_electric = np.stack((exact_ex, exact_ey), axis=-1)
+    error_density = (
+        EPS_0
+        * np.einsum("...i,...ij,...j->...", electric_error, epsilon, electric_error)
+        + MU_0 * (hz - exact_hz) ** 2
+    )
+    exact_density = (
+        EPS_0
+        * np.einsum("...i,...ij,...j->...", exact_electric, epsilon, exact_electric)
+        + MU_0 * exact_hz**2
+    )
+    # The run lasts 0.2 L/c, so boundary disturbances travel at most 1.6 um.
+    margin = 2.0 * bz.um
+    mask = (
+        (x >= margin) & (x <= length - margin) & (y >= margin) & (y <= length - margin)
+    )
+    return math.sqrt(float(np.sum(error_density[mask]) / np.sum(exact_density[mask])))
+
+
+def _convergence_statistics(grids, errors):
+    """Return pairwise orders and a log-log fit over the three finest grids."""
+
+    pairwise_orders = tuple(
+        math.log2(coarse / fine)
+        for coarse, fine in zip(errors[:-1], errors[1:], strict=True)
+    )
+    log_spacing = np.log(8.0 * bz.um / np.asarray(grids[-3:], dtype=float))
+    log_error = np.log(np.asarray(errors[-3:], dtype=float))
+    fitted_order, intercept = np.polyfit(log_spacing, log_error, 1)
+    fitted = fitted_order * log_spacing + intercept
+    residual = np.sum((log_error - fitted) ** 2)
+    total = np.sum((log_error - np.mean(log_error)) ** 2)
+    return pairwise_orders, float(fitted_order), float(1.0 - residual / total)
 
 
 @pytest.mark.simulation
-def test_sloped_interface_fdtd_converges_under_grid_refinement():
-    coarse, medium, fine = (_sloped_interface_probe(cells) for cells in (48, 96, 192))
-    observed_order = math.log2(abs(coarse - medium) / abs(medium - fine))
+@pytest.mark.parametrize(
+    ("angle_degrees", "interface_offset"),
+    (
+        (17.0, 0.07 * bz.um),
+        (27.0, 0.07 * bz.um),
+        (27.0, -0.11 * bz.um),
+        (41.0, -0.11 * bz.um),
+    ),
+)
+def test_sloped_anisotropic_interface_matches_exact_pulse_at_second_order(
+    angle_degrees,
+    interface_offset,
+    validation_metrics,
+):
+    """Global Ex/Ey/Hz error converges quadratically across angle and grid phase."""
 
-    assert abs(medium - fine) < abs(coarse - medium)
-    assert 1.5 < observed_order < 2.4
+    grids = (48, 96, 192, 384)
+    errors = tuple(
+        _analytical_interface_error(
+            cells,
+            angle_degrees=angle_degrees,
+            interface_offset=interface_offset,
+        )
+        for cells in grids
+    )
+    orders, fitted_order, fit_r_squared = _convergence_statistics(grids, errors)
+    metadata = {
+        "angle_degrees": angle_degrees,
+        "interface_offset_um": interface_offset / bz.um,
+        "grid_sizes": list(grids),
+        "normalized_energy_errors": list(errors),
+        "pairwise_orders": list(orders),
+        "oracle": "exact source-free normal-incidence pulse",
+        "epsilon_right_normal_tangent": [6.0, 4.0],
+    }
+
+    assert all(
+        coarse > fine for coarse, fine in zip(errors[:-1], errors[1:], strict=True)
+    )
+    assert all(1.8 < order < 2.2 for order in orders[-2:])
+    assert fitted_order < 2.2
+    validation_metrics.check_lower(
+        "asymptotic global-field convergence order",
+        measured=fitted_order,
+        lower_bound=1.8,
+        resolution="96 -> 192 -> 384 cells",
+        metadata=metadata,
+    )
+    validation_metrics.check_lower(
+        "convergence log-log fit R-squared",
+        measured=fit_r_squared,
+        lower_bound=0.999,
+        resolution="96 -> 192 -> 384 cells",
+        metadata=metadata,
+    )
+
+
+@pytest.mark.simulation
+@pytest.mark.parametrize(
+    ("anisotropic", "control", "minimum_gain", "maximum_control_order"),
+    (
+        (True, "farjadpour_diagonal", 10.0, 1.0),
+        (False, "volume", 3.0, 1.6),
+    ),
+)
+def test_full_farjadpour_convergence_is_sensitive_to_weaker_material_controls(
+    anisotropic,
+    control,
+    minimum_gain,
+    maximum_control_order,
+    validation_metrics,
+):
+    """Weaker material rules lose both fine-grid accuracy and asymptotic order."""
+
+    grids = (48, 96, 192, 384)
+    arguments = {"angle_degrees": 27.0, "interface_offset": -0.11 * bz.um}
+    full_errors = tuple(
+        _analytical_interface_error(cells, anisotropic=anisotropic, **arguments)
+        for cells in grids
+    )
+    control_errors = tuple(
+        _analytical_interface_error(
+            cells,
+            anisotropic=anisotropic,
+            smoothing=control,
+            **arguments,
+        )
+        for cells in grids
+    )
+    control_orders, _, _ = _convergence_statistics(grids, control_errors)
+    fine_grid_gain = control_errors[-1] / full_errors[-1]
+    metadata = {
+        "control": control,
+        "anisotropic_material": anisotropic,
+        "grid_sizes": list(grids),
+        "full_errors": list(full_errors),
+        "control_errors": list(control_errors),
+        "control_pairwise_orders": list(control_orders),
+    }
+
+    validation_metrics.check_lower(
+        "full Farjadpour fine-grid accuracy gain",
+        measured=fine_grid_gain,
+        lower_bound=minimum_gain,
+        unit="times",
+        resolution="384 cells",
+        metadata=metadata,
+    )
+    validation_metrics.check_upper(
+        "weaker-control finest-pair convergence order",
+        measured=control_orders[-1],
+        upper_bound=maximum_control_order,
+        resolution="192 -> 384 cells",
+        metadata=metadata,
+    )
 
 
 def _te_energy(state) -> float:

--- a/tests/validation/convergence/test_full_tensor_fdtd_convergence.py
+++ b/tests/validation/convergence/test_full_tensor_fdtd_convergence.py
@@ -6,8 +6,11 @@ import math
 
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
+import beamz as bz
 from beamz.const import EPS_0, LIGHT_SPEED, MU_0
+from beamz.design import raster
 from beamz.lattice import advance_h_field
 from beamz.simulation.kernels import (
     advance_e_centered_tensor,
@@ -71,3 +74,111 @@ def test_full_tensor_te_update_is_second_order_under_refinement():
     observed_order = math.log2(abs(coarse - medium) / abs(medium - fine))
 
     assert 1.5 < observed_order < 2.2
+
+
+def _sloped_interface_simulation(cells: int, time: np.ndarray):
+    length = 4.0 * bz.um
+    spacing = length / cells
+    scene = raster.Scene(
+        (raster.Material(), raster.Material(4.0)),
+        (
+            raster.Object(
+                raster.ExtrudedPolygon(
+                    raster.Polygon(
+                        (
+                            (-length, 2.0 * length),
+                            (2.0 * length, -length),
+                            (2.0 * length, 2.0 * length),
+                        )
+                    ),
+                    0.0,
+                    1.0,
+                ),
+                1,
+            ),
+        ),
+    )
+    simulation = bz.Simulation(
+        scene=scene,
+        raster_grid=raster.Grid.uniform(
+            (0.0, 0.0, 0.0), (length, length, 1.0), (cells, cells, 1)
+        ),
+        polarization="te",
+        time=time,
+        sources=(),
+        normalize_source=None,
+        raster_options=raster.RasterOptions(smoothing="farjadpour_full"),
+    )
+    state = simulation.initial_state()
+    coordinates = (np.arange(cells) + 0.5) * spacing
+    y, x = np.meshgrid(coordinates, coordinates, indexing="ij")
+    initial_hz = np.exp(
+        -((x - 1.7 * bz.um) ** 2 + (y - 1.7 * bz.um) ** 2) / (2.0 * (0.18 * bz.um) ** 2)
+    )
+    state = state._replace(hz=jnp.asarray(initial_hz, dtype=state.hz.dtype))
+    return simulation, state
+
+
+def _sloped_interface_probe(cells: int) -> float:
+    length = 4.0 * bz.um
+    spacing = length / cells
+    steps = cells
+    duration = 3.0e-15
+    simulation, state = _sloped_interface_simulation(
+        cells, np.arange(steps) * (duration / steps)
+    )
+    coordinates = (np.arange(cells) + 0.5) * spacing
+    y, x = np.meshgrid(coordinates, coordinates, indexing="ij")
+    final_hz = np.asarray(
+        simulation.advance(state=state, progress=False).state.hz,
+        dtype=np.float64,
+    )
+    probe = np.exp(
+        -((x - 2.1 * bz.um) ** 2 + (y - 2.1 * bz.um) ** 2) / (2.0 * (0.35 * bz.um) ** 2)
+    )
+    return float(spacing**2 * np.sum(probe * final_hz**2))
+
+
+@pytest.mark.simulation
+def test_sloped_interface_fdtd_converges_under_grid_refinement():
+    coarse, medium, fine = (_sloped_interface_probe(cells) for cells in (48, 96, 192))
+    observed_order = math.log2(abs(coarse - medium) / abs(medium - fine))
+
+    assert abs(medium - fine) < abs(coarse - medium)
+    assert 1.5 < observed_order < 2.4
+
+
+def _te_energy(state) -> float:
+    electric = np.sum(np.asarray(state.ex, dtype=np.float64) ** 2) + np.sum(
+        np.asarray(state.ey, dtype=np.float64) ** 2
+    )
+    magnetic = np.sum(np.asarray(state.hz, dtype=np.float64) ** 2)
+    return float(EPS_0 * electric + MU_0 * magnetic)
+
+
+@pytest.mark.simulation
+def test_sloped_interface_full_tensor_update_is_stable_for_four_thousand_steps():
+    cells = 48
+    spacing = 4.0 * bz.um / cells
+    segment_steps = 500
+    segments = 8
+    dt = 0.2 * spacing / LIGHT_SPEED
+    simulation, state = _sloped_interface_simulation(
+        cells, np.arange(segment_steps * segments) * dt
+    )
+    initial_energy = _te_energy(state)
+    energies = []
+
+    for _ in range(segments):
+        state = simulation.advance(
+            state=state,
+            num_steps=segment_steps,
+            progress=False,
+        ).state
+        assert all(
+            np.all(np.isfinite(np.asarray(field)))
+            for field in (state.ex, state.ey, state.hz)
+        )
+        energies.append(_te_energy(state))
+
+    assert max(energies) < 2.0 * initial_energy

--- a/tests/validation/convergence/test_full_tensor_fdtd_convergence.py
+++ b/tests/validation/convergence/test_full_tensor_fdtd_convergence.py
@@ -1,0 +1,83 @@
+"""Convergence of the full-tensor TE FDTD constitutive update."""
+
+from __future__ import annotations
+
+import math
+
+import jax.numpy as jnp
+import numpy as np
+
+from beamz.const import EPS_0, LIGHT_SPEED, MU_0
+from beamz.lattice import advance_h_field
+from beamz.simulation.kernels import (
+    advance_e_full_tensor,
+    te_xy_curl_e_to_h_2d,
+    te_xy_curl_h_to_e_2d,
+)
+
+
+def _centroid(field, spacing):
+    energy = np.sum(np.asarray(field) ** 2, axis=0)
+    coordinates = (np.arange(energy.size) + 0.5) * spacing
+    return float(np.sum(coordinates * energy) / np.sum(energy))
+
+
+def _anisotropic_packet_displacement(cells: int) -> float:
+    length = 192e-6
+    spacing = length / cells
+    epsilon = np.asarray(((2.0, 0.8), (0.8, 3.0)))
+    inverse = np.linalg.inv(epsilon)
+    effective_epsilon = np.linalg.det(epsilon) / epsilon[0, 0]
+    impedance = np.sqrt(MU_0 / (EPS_0 * effective_epsilon))
+    x_e = np.arange(cells + 1) * spacing
+    x_h = (np.arange(cells) + 0.5) * spacing
+    center, width, wavelength = 60e-6, 12e-6, 24e-6
+
+    def packet(x):
+        return np.exp(-(((x - center) / width) ** 2)) * np.cos(
+            2.0 * np.pi * (x - center) / wavelength
+        )
+
+    ey = jnp.asarray(np.tile(packet(x_e), (4, 1)), dtype=jnp.float32)
+    ex = jnp.asarray(
+        np.tile((-epsilon[0, 1] / epsilon[0, 0]) * packet(x_h), (5, 1)),
+        dtype=jnp.float32,
+    )
+    hz = jnp.asarray(np.tile(packet(x_h) / impedance, (4, 1)), dtype=jnp.float32)
+    rows = (
+        jnp.stack(
+            (
+                jnp.full_like(ex, inverse[0, 0]),
+                jnp.full_like(ex, inverse[0, 1]),
+                jnp.zeros_like(ex),
+            ),
+            axis=-1,
+        ),
+        jnp.stack(
+            (
+                jnp.full_like(ey, inverse[1, 0]),
+                jnp.full_like(ey, inverse[1, 1]),
+                jnp.zeros_like(ey),
+            ),
+            axis=-1,
+        ),
+    )
+    start = _centroid(hz, spacing)
+    duration = 30e-15
+    steps = round(duration / (0.2 * spacing / LIGHT_SPEED))
+    dt = duration / steps
+    for _ in range(steps):
+        curl_hz = te_xy_curl_e_to_h_2d(ex, ey, spacing, hz.shape)
+        hz = advance_h_field(hz, curl_hz, 0.0, dt)
+        curls = te_xy_curl_h_to_e_2d(hz, spacing, ex.shape, ey.shape, frozenset())
+        ex, ey = advance_e_full_tensor((ex, ey), curls, rows, ("Ex", "Ey"), dt)
+    return _centroid(hz, spacing) - start
+
+
+def test_full_tensor_te_update_is_second_order_under_refinement():
+    coarse, medium, fine = (
+        _anisotropic_packet_displacement(cells) for cells in (96, 192, 384)
+    )
+    observed_order = math.log2(abs(coarse - medium) / abs(medium - fine))
+
+    assert 1.5 < observed_order < 2.2

--- a/tests/validation/convergence/test_rasterized_mode_convergence.py
+++ b/tests/validation/convergence/test_rasterized_mode_convergence.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import numpy as np
 import pytest
 
@@ -10,7 +12,7 @@ from beamz.devices.modes.solver import solve_grid
 
 
 def _rotated_waveguide_scene() -> raster.Scene:
-    corners = np.asarray(((-0.5, -0.225), (0.5, -0.225), (0.5, 0.225), (-0.5, 0.225)))
+    corners = np.asarray(((-0.5, -0.15), (0.5, -0.15), (0.5, 0.15), (-0.5, 0.15)))
     angle = np.deg2rad(27.0)
     rotation = np.asarray(
         ((np.cos(angle), -np.sin(angle)), (np.sin(angle), np.cos(angle)))
@@ -57,12 +59,11 @@ def _effective_index(scene: raster.Scene, cells: int) -> float:
 @pytest.mark.simulation
 def test_farjadpour_waveguide_mode_converges_under_grid_refinement():
     scene = _rotated_waveguide_scene()
-    coarse = _effective_index(scene, 16)
-    fine = _effective_index(scene, 32)
-    reference = _effective_index(scene, 64)
+    coarse = _effective_index(scene, 12)
+    medium = _effective_index(scene, 24)
+    fine = _effective_index(scene, 48)
 
-    coarse_error = abs(coarse - reference)
-    fine_error = abs(fine - reference)
+    observed_order = math.log2(abs(coarse - medium) / abs(medium - fine))
     assert 1.44 < coarse < 3.4
     assert 1.44 < fine < 3.4
-    assert fine_error < 0.6 * coarse_error
+    assert 1.5 < observed_order < 2.3

--- a/tests/validation/invariants/test_te_xy_full_yee.py
+++ b/tests/validation/invariants/test_te_xy_full_yee.py
@@ -8,9 +8,46 @@ from beamz.const import EPS_0, LIGHT_SPEED, MU_0
 from beamz.devices._boundary_compile import compile_metallic_masks
 from beamz.lattice import advance_e_field, advance_h_field, component_shapes
 from beamz.simulation.kernels import (
+    advance_e_full_tensor,
     te_xy_curl_e_to_h_2d,
     te_xy_curl_h_to_e_2d,
 )
+
+
+def test_full_tensor_e_update_applies_cross_component_coupling():
+    ex = jnp.zeros((4, 5), dtype=jnp.float32)
+    ey = jnp.zeros((3, 6), dtype=jnp.float32)
+    curl_ex = jnp.ones_like(ex)
+    curl_ey = 2.0 * jnp.ones_like(ey)
+    epsilon = np.asarray(((2.0, 0.5), (0.5, 3.0)))
+    inverse = np.linalg.inv(epsilon)
+    row_x = jnp.stack(
+        (
+            jnp.full_like(ex, inverse[0, 0]),
+            jnp.full_like(ex, inverse[0, 1]),
+            jnp.zeros_like(ex),
+        ),
+        axis=-1,
+    )
+    row_y = jnp.stack(
+        (
+            jnp.full_like(ey, inverse[1, 0]),
+            jnp.full_like(ey, inverse[1, 1]),
+            jnp.zeros_like(ey),
+        ),
+        axis=-1,
+    )
+
+    updated_ex, updated_ey = advance_e_full_tensor(
+        (ex, ey),
+        (curl_ex, curl_ey),
+        (row_x, row_y),
+        ("Ex", "Ey"),
+        EPS_0,
+    )
+
+    np.testing.assert_allclose(updated_ex, inverse[0] @ (1.0, 2.0))
+    np.testing.assert_allclose(updated_ey, inverse[1] @ (1.0, 2.0))
 
 
 def _step(ex, ey, hz, *, dx, dt, edges=frozenset()):

--- a/tests/validation/invariants/test_te_xy_full_yee.py
+++ b/tests/validation/invariants/test_te_xy_full_yee.py
@@ -8,7 +8,7 @@ from beamz.const import EPS_0, LIGHT_SPEED, MU_0
 from beamz.devices._boundary_compile import compile_metallic_masks
 from beamz.lattice import advance_e_field, advance_h_field, component_shapes
 from beamz.simulation.kernels import (
-    advance_e_full_tensor,
+    advance_e_centered_tensor,
     te_xy_curl_e_to_h_2d,
     te_xy_curl_h_to_e_2d,
 )
@@ -21,33 +21,58 @@ def test_full_tensor_e_update_applies_cross_component_coupling():
     curl_ey = 2.0 * jnp.ones_like(ey)
     epsilon = np.asarray(((2.0, 0.5), (0.5, 3.0)))
     inverse = np.linalg.inv(epsilon)
-    row_x = jnp.stack(
-        (
-            jnp.full_like(ex, inverse[0, 0]),
-            jnp.full_like(ex, inverse[0, 1]),
-            jnp.zeros_like(ex),
-        ),
-        axis=-1,
+    diagonals = (
+        jnp.full_like(ex, inverse[0, 0]),
+        jnp.full_like(ey, inverse[1, 1]),
     )
-    row_y = jnp.stack(
-        (
-            jnp.full_like(ey, inverse[1, 0]),
-            jnp.full_like(ey, inverse[1, 1]),
-            jnp.zeros_like(ey),
-        ),
-        axis=-1,
-    )
+    offdiagonal = jnp.zeros((4, 6, 3), dtype=jnp.float32)
+    offdiagonal = offdiagonal.at[..., 0].set(inverse[0, 1])
 
-    updated_ex, updated_ey = advance_e_full_tensor(
+    updated_ex, updated_ey = advance_e_centered_tensor(
         (ex, ey),
         (curl_ex, curl_ey),
-        (row_x, row_y),
+        diagonals,
+        offdiagonal,
         ("Ex", "Ey"),
         EPS_0,
     )
 
     np.testing.assert_allclose(updated_ex, inverse[0] @ (1.0, 2.0))
     np.testing.assert_allclose(updated_ey, inverse[1] @ (1.0, 2.0))
+
+
+def test_full_tensor_cross_term_multiplies_between_the_two_averages():
+    ex = jnp.zeros((4, 4), dtype=jnp.float32)
+    ey = jnp.zeros((3, 5), dtype=jnp.float32)
+    curl_ex = jnp.zeros_like(ex)
+    curl_ey = jnp.asarray(
+        [[1.0, 2.0, 4.0, 8.0, 16.0]] * 3,
+        dtype=jnp.float32,
+    )
+    offdiagonal = jnp.zeros((4, 5, 3), dtype=jnp.float32)
+    xy = jnp.asarray(np.arange(20, dtype=np.float32).reshape(4, 5) + 1.0)
+    offdiagonal = offdiagonal.at[..., 0].set(xy)
+
+    updated_ex, _ = advance_e_centered_tensor(
+        (ex, ey),
+        (curl_ex, curl_ey),
+        (jnp.zeros_like(ex), jnp.zeros_like(ey)),
+        offdiagonal,
+        ("Ex", "Ey"),
+        EPS_0,
+    )
+
+    centered_ey = np.concatenate(
+        (
+            np.asarray(curl_ey[:1]),
+            0.5 * np.asarray(curl_ey[:-1] + curl_ey[1:]),
+            np.asarray(curl_ey[-1:]),
+        ),
+        axis=0,
+    )
+    weighted = np.asarray(xy) * centered_ey
+    expected_ex = 0.5 * (weighted[:, :-1] + weighted[:, 1:])
+    np.testing.assert_allclose(updated_ex, expected_ex)
 
 
 def _step(ex, ey, hz, *, dx, dt, edges=frozenset()):


### PR DESCRIPTION
## Summary

- make Farjadpour smoothing the default, retaining full tensors for standalone rasterization while simulations default to the diagonal policy and can explicitly request full coupling
- compile inverse diagonal permittivity at the Ex/Ey/Ez supports and inverse off-diagonal terms at the shared grid nodes
- implement the paper's stable average-multiply-average anisotropic coupling in 2D TE and 3D FDTD, including CPML and sharded coefficient lowering
- keep mode launches on supported diagonal Yee materials while rejecting unsupported full off-diagonal mode solves
- add exact sloped-interface convergence and long-run stability evidence

## Convergence evidence

The end-to-end benchmark initializes an exact source-free normal-incidence TE pulse at a sloped anisotropic interface and measures the global normalized Ex/Ey/Hz energy error across 48, 96, 192, and 384 cells.

- interface angles and grid phases: 17°, 27°, and 41° with positive and negative offsets
- fitted asymptotic orders: 1.859–1.932
- log-log fit R²: greater than 0.99993
- full Farjadpour is 14.5× more accurate than the diagonal anisotropic control at 384 cells
- full Farjadpour is 4.1× more accurate than volume averaging for the isotropic control
- a sloped-interface full-tensor run remains finite and bounded for 4,000 steps

## Validation

- 855 passed and 1 expected xfail in the pull-request evidence gate
- all risk-weighted coverage floors passed
- Ruff, formatting, Pyright, and Vulture passed
- 41 Rust tests passed
- 4 fake multi-device CPU sharding tests passed
- 3D full-tensor sharded and unsharded updates agree

## Current limitations

Full-tensor electric coupling requires zero electric conductivity and unit permeability. Use CPML instead of conductive sponge PML with full coupling. Anisotropic permeability remains available in standalone raster output but is not yet consumed by FDTD.

Closes #183
