### PR TITLE
Fix mode-source launch power calibration

### DIFF
--- a/beamz/devices/sources/mode_launch.py
+++ b/beamz/devices/sources/mode_launch.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Literal, cast
 
 import numpy as np
@@ -13,10 +13,17 @@ from beamz.devices._immutable import readonly_array
 from beamz.devices._placement import (
     snap_mode_source_region,
     snap_mode_source_region_grid,
+    snap_plane_region,
+    snap_plane_region_grid,
 )
 from beamz.devices.modes.discrete import solve_beamz_mode
 from beamz.devices.modes.fields import _modal_power, _numeric_wave_number
 from beamz.devices.modes.plane import solve_mode_plane_3d, solve_modes
+from beamz.lattice import (
+    common_grid_shape_3d,
+    compile_yee_plane_quadrature_3d,
+    yee_flux,
+)
 
 from . import planar_tfsf
 from .solve import _require_cell_mode_materials
@@ -616,6 +623,78 @@ def _launch_amplitude_scale(launch_power_ratio: float | None) -> float:
     return float(1.0 / np.sqrt(ratio))
 
 
+def _reconstructed_3d_launch_phasor_state(
+    field_profile: FieldProfile3D,
+    residuals: tuple[planar_tfsf.ModeSource3DResidual, ...],
+    fields,
+    *,
+    resolution: float,
+    dt: float,
+) -> dict[str, np.ndarray]:
+    """Reconstruct the first complete incident Yee state produced by a launch."""
+    full_prev = planar_tfsf.build_incident_3d_phasor_state(
+        field_profile,
+        fields,
+        resolution=resolution,
+        t_e=0.0,
+        t_h=-0.5 * dt,
+        masked=False,
+        max_shift=12,
+    )
+    masked_prev = planar_tfsf.build_incident_3d_phasor_state(
+        field_profile,
+        fields,
+        resolution=resolution,
+        t_e=0.0,
+        t_h=-0.5 * dt,
+        masked=True,
+        max_shift=12,
+    )
+    h_full_next = planar_tfsf.advance_incident_h_3d(
+        fields, full_prev, dt, resolution=resolution
+    )
+    h_target_next = planar_tfsf.mask_incident_3d_state_to_launched_side(
+        field_profile,
+        h_full_next,
+        resolution=resolution,
+    )
+    h_mask_next = planar_tfsf.advance_incident_h_3d(
+        fields, masked_prev, dt, resolution=resolution
+    )
+    h_delta = _expand_3d_residuals(residuals, fields, ("Hx", "Hy", "Hz"))
+    e_mask_next = planar_tfsf.advance_incident_e_3d(
+        fields,
+        masked_prev,
+        h_target_next,
+        dt,
+        resolution=resolution,
+    )
+    e_delta = _expand_3d_residuals(residuals, fields, ("Ex", "Ey", "Ez"))
+    return {
+        "Ex": e_mask_next["Ex"] + e_delta["Ex"],
+        "Ey": e_mask_next["Ey"] + e_delta["Ey"],
+        "Ez": e_mask_next["Ez"] + e_delta["Ez"],
+        "Hx": h_mask_next["Hx"] + h_delta["Hx"],
+        "Hy": h_mask_next["Hy"] + h_delta["Hy"],
+        "Hz": h_mask_next["Hz"] + h_delta["Hz"],
+    }
+
+
+def _expand_3d_residuals(residuals, fields, components):
+    expanded = {
+        component: np.zeros_like(
+            np.asarray(getattr(fields, component)), dtype=np.complex128
+        )
+        for component in components
+    }
+    for residual in residuals:
+        if residual.component in expanded:
+            expanded[residual.component][residual.index] += np.asarray(
+                residual.residual, dtype=np.complex128
+            )
+    return expanded
+
+
 def _launch_power_diagnostics_3d(
     source: ModeSource,
     field_profile: FieldProfile3D,
@@ -626,24 +705,124 @@ def _launch_power_diagnostics_3d(
     dt: float | None,
     requested_power: float,
 ) -> tuple[float | None, float | None]:
-    del source, residuals, fields, resolution, dt
     if (not np.isfinite(requested_power)) or requested_power <= 1e-30:
         return None, None
-    weights = field_profile.power_weights
-    if not weights:
-        return None, None
-    launched_power = _modal_power(
-        field_profile.components,
-        axis=field_profile.axis,
-        measure=weights,
-        direction_sign=float(field_profile.direction_sign),
-    )
+    launched_power = None
+    if dt is not None and float(dt) > 0.0 and residuals:
+        try:
+            state = _reconstructed_3d_launch_phasor_state(
+                field_profile,
+                residuals,
+                fields,
+                resolution=float(resolution),
+                dt=float(dt),
+            )
+            profiles = planar_tfsf.deembed_3d_phasor_profiles(
+                field_profile,
+                state,
+                fields,
+                resolution=float(resolution),
+                t_e=float(dt),
+                t_h=0.5 * float(dt),
+            )
+            launched_power = _yee_plane_power_3d(
+                source,
+                replace(field_profile, components=profiles),
+                fields,
+                resolution=float(resolution),
+            )
+        except Exception:
+            launched_power = None
+    if launched_power is None:
+        weights = field_profile.power_weights
+        if not weights:
+            return None, None
+        launched_power = _modal_power(
+            field_profile.components,
+            axis=field_profile.axis,
+            measure=weights,
+            direction_sign=float(field_profile.direction_sign),
+        )
     ratio = float(launched_power / float(requested_power))
     if (not np.isfinite(ratio)) or ratio <= 1e-24:
         ratio = None
     if (not np.isfinite(launched_power)) or launched_power <= 1e-24:
         launched_power = None
     return ratio, launched_power
+
+
+def _yee_plane_power_3d(
+    source: ModeSource,
+    field_profile: FieldProfile3D,
+    fields,
+    *,
+    resolution: float,
+) -> float:
+    """Measure the incident mode with the flux monitor's Yee-plane quadrature."""
+    component_shapes = {
+        component: tuple(getattr(fields, component).shape)
+        for component in ("Ex", "Ey", "Ez", "Hx", "Hy", "Hz")
+    }
+    grid_shape = common_grid_shape_3d(fields)
+    geometry = getattr(fields, "geometry", None)
+    metric_grid = (
+        geometry
+        if geometry is not None and geometry.metric_kind != "isotropic_uniform"
+        else None
+    )
+    axis_index = {"x": 0, "y": 1, "z": 2}[source.axis]
+    lower = np.asarray(source.center) - 0.5 * np.asarray(source.size)
+    upper = np.asarray(source.center) + 0.5 * np.asarray(source.size)
+    lower[axis_index] = upper[axis_index] = source.center[axis_index]
+    if metric_grid is None:
+        region = snap_plane_region(
+            start=tuple(lower),
+            end=tuple(upper),
+            plane_normal=source.axis,
+            size=None,
+            dx=float(resolution),
+            dy=float(resolution),
+            dz=float(resolution),
+            shape=grid_shape,
+        )
+    else:
+        region = snap_plane_region_grid(
+            center=source.center,
+            size=source.size,
+            plane_normal=source.axis,
+            grid=metric_grid,
+        )
+    quadrature = compile_yee_plane_quadrature_3d(
+        center=source.center,
+        size=source.size,
+        normal_axis=source.axis,
+        region=region,
+        resolution=float(resolution),
+        grid_shape=grid_shape,
+        component_shapes=component_shapes,
+        grid=metric_grid,
+    )
+    state = planar_tfsf.build_incident_3d_phasor_state(
+        field_profile,
+        fields,
+        resolution=float(resolution),
+        t_e=0.0,
+        t_h=0.0,
+        masked=False,
+        max_shift=12,
+    )
+    power = yee_flux(
+        quadrature.sample(state),
+        quadrature.normal_axis,
+        normal_sign=float(field_profile.direction_sign),
+        measure=(
+            quadrature.integration_weights
+            if quadrature.integration_weights.size
+            else quadrature.sample_area
+        ),
+        phasor=True,
+    )
+    return float(np.asarray(power))
 
 
 def plan_mode_source_launch(

--- a/beamz/devices/sources/planar_tfsf.py
+++ b/beamz/devices/sources/planar_tfsf.py
@@ -155,6 +155,37 @@ def build_incident_3d_phasor_state(
     return field_arrays
 
 
+def deembed_3d_phasor_profiles(
+    field_profile: FieldProfile3D,
+    state: dict[str, np.ndarray],
+    fields,
+    *,
+    resolution: float,
+    t_e,
+    t_h,
+) -> dict[str, np.ndarray]:
+    """Return local source-plane phasors in the source profile gauge."""
+    axis = field_profile.axis
+    k_num = _require_k_axis(field_profile)
+    omega = float(field_profile.omega)
+    ref_coord = float(field_profile.phase_ref_coord)
+    out: dict[str, np.ndarray] = {}
+    for component in _FIELD_COMPONENTS_3D:
+        idx = field_profile.indices.get(component)
+        if idx is None or component not in state:
+            continue
+        values = np.asarray(state[component], dtype=np.complex128)
+        axis_idx = _axis_index(idx, axis)
+        coord = _component_axis_coordinate(
+            fields, component, axis, axis_idx, resolution
+        )
+        base_time = float(t_e if component.startswith("E") else t_h)
+        delay = _phase_delay(omega, k_num, coord - ref_coord)
+        phase = omega * (base_time - delay)
+        out[component] = values[idx] * np.exp(-1j * phase)
+    return out
+
+
 def launched_side_component_mask_3d(
     field_profile: FieldProfile3D,
     component: str,

--- a/tests/integration/test_mode_launch_planner.py
+++ b/tests/integration/test_mode_launch_planner.py
@@ -482,7 +482,7 @@ def test_mode_launch_amplitude_scale_normalizes_measured_launch_power():
     assert _launch_amplitude_scale(0.0) == pytest.approx(1.0)
 
 
-def test_launch_diagnostics_use_mode_profile_power_contract():
+def test_launch_diagnostics_fall_back_to_mode_profile_power_contract():
     fields = _uniform_3d_fields()
     source = _mode_source(power=2.0)
     profile = np.ones((2, 2), dtype=np.complex128)
@@ -513,6 +513,62 @@ def test_launch_diagnostics_use_mode_profile_power_contract():
 
     assert power == pytest.approx(2.0)
     assert ratio == pytest.approx(1.0)
+
+
+def test_launch_diagnostics_prefer_reconstructed_yee_plane_power(monkeypatch):
+    fields = _uniform_3d_fields()
+    source = _mode_source(power=2.0)
+    profile = np.ones((2, 2), dtype=np.complex128)
+    field_profile = FieldProfile3D(
+        components={"Ey": profile, "Hz": profile},
+        indices={
+            "Ey": (slice(1, 3), slice(1, 3), 1),
+            "Hz": (slice(1, 3), slice(1, 3), 1),
+        },
+        axis="x",
+        direction_sign=1.0,
+        omega=2.0,
+        k_axis=1.0,
+        phase_ref_coord=1.5,
+        phase_plane_coord=1.5,
+        power_weights={"Ey": np.ones((2, 2))},
+    )
+    residual = ModeSource3DResidual(
+        component="Ey",
+        timing="pre_e",
+        index=(slice(1, 3), slice(1, 3), 1),
+        residual=profile,
+    )
+    state = {"Ey": np.ones_like(fields.Ey)}
+
+    monkeypatch.setattr(
+        mode_launch_module,
+        "_reconstructed_3d_launch_phasor_state",
+        lambda *args, **kwargs: state,
+    )
+    monkeypatch.setattr(
+        mode_launch_module.planar_tfsf,
+        "deembed_3d_phasor_profiles",
+        lambda *args, **kwargs: field_profile.components,
+    )
+    monkeypatch.setattr(
+        mode_launch_module,
+        "_yee_plane_power_3d",
+        lambda *args, **kwargs: 2.5,
+    )
+
+    ratio, power = _launch_power_diagnostics_3d(
+        source,
+        field_profile,
+        (residual,),
+        fields,
+        resolution=1.0,
+        dt=0.1,
+        requested_power=2.0,
+    )
+
+    assert power == pytest.approx(2.5)
+    assert ratio == pytest.approx(1.25)
 
 
 def test_mode_launch_plan_reports_scaled_net_launched_power():

--- a/tests/integration/test_mode_source_integration.py
+++ b/tests/integration/test_mode_source_integration.py
@@ -87,6 +87,18 @@ def test_3d_mode_source_suppresses_counterpropagating_power_on_both_grids(
         run_time=6.0 / frequency,
     )
 
+    program = simulation.compile()
+    if grid_kind == "uniform":
+        assert program.grid.geometry.metric_kind == "isotropic_uniform"
+    else:
+        assert program.grid.geometry.metric_kind != "isotropic_uniform"
+    launch_powers = {
+        float(spec.launched_power)
+        for spec in program.sources
+        if spec.launched_power is not None
+    }
+    assert sorted(launch_powers) == pytest.approx([source.power], rel=1e-6)
+
     result = simulation.run(progress=False)
     counter_power = abs(float(result["counter"].flux[0]))
     forward_power = abs(float(result["forward"].flux[0]))


### PR DESCRIPTION
## Summary

- restore reconstructed 3D incident Yee-state calibration for mode sources
- measure launch power with the same colocated Yee-plane Poynting quadrature used by flux monitors
- use realized per-cell integration areas on nonuniform rectilinear grids
- retain mode-profile power as a safe fallback when reconstruction is unavailable
- add regression coverage for reconstructed calibration and genuine uniform/nonuniform grids

## Root cause

The rectilinear-grid refactor replaced the reconstructed launch-state power calculation with mode-solver quadrature and removed its de-embedding helper. The two quadratures differ by a few percent for the actual injected staggered Yee fields. A nominal 1 W source therefore emitted about 1.03 W in the cosine-crossing example, turning a small passive loss into apparent gain.

## Impact

Flux monitors remain source-normalized without requiring a reference simulation or input normalization monitor. The cosine waveguide crossing now reports approximately -0.10 to -0.18 dB transmission on its regular grid. A separate nonuniform-grid GPU run remains passive and exercises metric-aware calibration; its remaining numerical difference is attributable to changed slab discretization/effective index.

## Validation

- `ruff check` on changed Python files
- `git diff --check`
- 28 mode launch/source integration tests
- 22 documentation notebook tests
- 26 launch-planner plus explicit uniform/nonuniform-grid tests
- 14 mode-source and flux-normalization contract/integration tests
- full cosine crossing notebook on an NVIDIA RTX 3090
- nonuniform rectilinear variant on an NVIDIA RTX 3090
