### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,7 +193,7 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdtd-raster-core"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "approx",
  "blake3",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "fdtd-raster-py"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "fdtd-raster-core",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/beamzorg/beamz"

--- a/beamz/__init__.py
+++ b/beamz/__init__.py
@@ -136,4 +136,4 @@ __all__ = [
 
 
 # Version information
-__version__ = "0.4.3"
+__version__ = "0.5.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ test = [ # Adding a 'test' extra that includes pytest and pytest-cov for conveni
 
 [tool.ruff]
 line-length = 88
-target-version = "0.5.0"
+target-version = "py310"
 extend-exclude = ["*.ipynb"]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "beamz"
-version = "0.4.3"
+version = "0.5.0"
 dynamic = []
 authors = [
     { name = "Quentin Wach", email = "quentin.wach+beamz@gmail.com" },
@@ -89,7 +89,7 @@ test = [ # Adding a 'test' extra that includes pytest and pytest-cov for conveni
 
 [tool.ruff]
 line-length = 88
-target-version = "py310"
+target-version = "0.5.0"
 extend-exclude = ["*.ipynb"]
 
 [tool.ruff.lint]

--- a/release_version.py
+++ b/release_version.py
@@ -139,7 +139,10 @@ def update_version(version):
     # Update pyproject.toml (primary source of truth)
     changes.append(
         update_version_in_file(
-            "pyproject.toml", version, r'version = "[^"]+"', 'version = "{version}"'
+            "pyproject.toml",
+            version,
+            r'(?m)^version\s*=\s*"[^"]+"',
+            'version = "{version}"',
         )
     )
 

--- a/release_version.py
+++ b/release_version.py
@@ -170,6 +170,7 @@ def commit_version_changes(version):
     """Commit the version changes to git."""
     files_to_add = [
         "pyproject.toml",
+        "uv.lock",
         "beamz/__init__.py",
         "Cargo.toml",
         "Cargo.lock",
@@ -306,6 +307,7 @@ def main():
                 sys.exit(1)
         else:
             # Commit the changes so the tag points to the version bump commit
+            subprocess.run(["uv", "lock"], check=True)
             commit_version_changes(args.version)
 
     # Create git tag

--- a/tests/unit/test_release_version.py
+++ b/tests/unit/test_release_version.py
@@ -10,7 +10,8 @@ import release_version
 def _write_release_fixture(root: Path) -> None:
     (root / "beamz").mkdir()
     (root / "pyproject.toml").write_text(
-        '[project]\nname = "beamz"\nversion = "0.4.3"\n'
+        '[project]\nname = "beamz"\nversion = "0.4.3"\n\n'
+        '[tool.ruff]\ntarget-version = "py310"\n'
     )
     (root / "beamz" / "__init__.py").write_text('__version__ = "0.4.3"\n')
     (root / "Cargo.toml").write_text(
@@ -42,7 +43,9 @@ def test_update_version_keeps_python_and_native_engine_versions_in_sync(
 
     assert release_version.update_version("0.5.0")
 
-    assert 'version = "0.5.0"' in (tmp_path / "pyproject.toml").read_text()
+    pyproject = (tmp_path / "pyproject.toml").read_text()
+    assert 'version = "0.5.0"' in pyproject
+    assert 'target-version = "py310"' in pyproject
     assert '__version__ = "0.5.0"' in (tmp_path / "beamz" / "__init__.py").read_text()
     assert (
         '[workspace.package]\nversion = "0.5.0"'

--- a/tests/unit/test_release_version.py
+++ b/tests/unit/test_release_version.py
@@ -14,6 +14,7 @@ def _write_release_fixture(root: Path) -> None:
         '[tool.ruff]\ntarget-version = "py310"\n'
     )
     (root / "beamz" / "__init__.py").write_text('__version__ = "0.4.3"\n')
+    (root / "uv.lock").write_text("version = 1\n")
     (root / "Cargo.toml").write_text(
         '[workspace]\nmembers = []\n\n[workspace.package]\nversion = "0.4.3"\n'
     )
@@ -106,6 +107,7 @@ def test_commit_version_changes_stages_python_and_rust_metadata(tmp_path, monkey
     staged = [command[-1] for command, _check in calls if command[:2] == ["git", "add"]]
     assert staged == [
         "pyproject.toml",
+        "uv.lock",
         "beamz/__init__.py",
         "Cargo.toml",
         "Cargo.lock",

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ wheels = [
 
 [[package]]
 name = "beamz"
-version = "0.4.3"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "jax", version = "0.6.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- Bump the Python package and Rust workspace metadata from 0.4.3 to 0.5.0.
- Keep the Python, Rust workspace, and Cargo lockfile versions synchronized for the release tag.

## Validation

- release_version.py --verify 0.5.0
