### PR TITLE
Use supported macOS Intel release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             manylinux: "2_17"
-          - os: macos-13
+          - os: macos-15
             target: x86_64-apple-darwin
             manylinux: "off"
           - os: macos-14


### PR DESCRIPTION
Replaces the retired `macos-13` release runner label with supported Intel `macos-15`. Both failed v0.5.0 release attempts remained queued indefinitely on `macos-13`; the other platform wheels passed.