### PR TITLE
Use Intel runner for macOS x86 wheel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             manylinux: "2_17"
-          - os: macos-15
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             manylinux: "off"
           - os: macos-14


### PR DESCRIPTION
The `macos-15` label resolved to an ARM64 runner, which cannot install the x86_64 wheel produced by this matrix lane. Use the explicit Intel runner label so the installed-wheel smoke test runs on a compatible platform.