### PR TITLE
Make field plot colorbars aspect-aware

### DIFF
--- a/beamz/analysis/plotting.py
+++ b/beamz/analysis/plotting.py
@@ -1069,8 +1069,6 @@ def _plot_image(
         vmax=vmax,
         interpolation=interpolation,
     )
-    if colorbar:
-        fig.colorbar(im, ax=ax)
     ax.set_xlabel(xlabel)
     ax.set_ylabel(ylabel)
     if title:
@@ -1079,7 +1077,9 @@ def _plot_image(
         ax.set_xlim(*xlim)
     if ylim is not None:
         ax.set_ylim(*ylim)
-    fig.tight_layout()
+    if colorbar:
+        _add_field_colorbar(fig, ax, im)
+    fig.tight_layout(pad=0.5)
     _maybe_show(fig, show=show)
     return fig, ax
 
@@ -1253,6 +1253,33 @@ def _field_colorbar_label(
     if show_units and units:
         text += f" ({f'({units})^2' if view.power else units})"
     return text
+
+
+def _add_field_colorbar(fig, ax, image, **kwargs):
+    """Add a compact colorbar whose orientation follows the visible field extent."""
+    x0, x1 = ax.get_xlim()
+    y0, y1 = ax.get_ylim()
+    x_span = abs(x1 - x0)
+    y_span = abs(y1 - y0)
+    if y_span >= x_span:
+        return fig.colorbar(
+            image,
+            ax=ax,
+            location="right",
+            fraction=0.05,
+            pad=0.04,
+            aspect=30,
+            **kwargs,
+        )
+    return fig.colorbar(
+        image,
+        ax=ax,
+        location="bottom",
+        fraction=0.075,
+        pad=0.08,
+        aspect=35,
+        **kwargs,
+    )
 
 
 def _overlay_material_slice(
@@ -1524,20 +1551,6 @@ def plot_dft_field(
             alpha=float(grid_alpha),
         )
 
-    cbar_label = _field_colorbar_label(
-        field_key,
-        view,
-        display_field=display_field,
-        units=field_units,
-        show_units=show_units,
-    )
-    if colorbar:
-        fig.colorbar(
-            im,
-            ax=ax,
-            label=cbar_label,
-            extend="max" if view.magnitude else "both",
-        )
     ax.set_xlabel(f"{axis1} (um)")
     ax.set_ylabel(f"{axis0} (um)")
     plane_value = float(getattr(monitor, "plane_position", 0.0)) - origin_by_axis[axis]
@@ -1546,7 +1559,21 @@ def plot_dft_field(
         ax.set_xlim(*xlim)
     if ylim is not None:
         ax.set_ylim(*ylim)
-    fig.tight_layout()
+    if colorbar:
+        _add_field_colorbar(
+            fig,
+            ax,
+            im,
+            label=_field_colorbar_label(
+                field_key,
+                view,
+                display_field=display_field,
+                units=field_units,
+                show_units=show_units,
+            ),
+            extend="max" if view.magnitude else "both",
+        )
+    fig.tight_layout(pad=0.5)
     _maybe_show(fig, show=show)
     return fig, ax
 

--- a/tests/integration/test_simulation_plotting.py
+++ b/tests/integration/test_simulation_plotting.py
@@ -7,7 +7,11 @@ import numpy as np
 import pytest
 
 import beamz as bz
-from beamz.analysis.plotting import extract_axis_aligned_slice, plot_field_view
+from beamz.analysis.plotting import (
+    _plot_image,
+    extract_axis_aligned_slice,
+    plot_field_view,
+)
 from beamz.design import MaterialGrid
 from beamz.design.raster import Grid, Material, Scene, rasterize
 
@@ -31,6 +35,29 @@ def test_generic_slice_and_field_primitives_preserve_axis_coordinates():
         image, view = plot_field_view(ax, section.values * (1.0 + 1.0j), val="abs^2")
         np.testing.assert_allclose(image.get_array(), 2.0 * section.values**2)
         assert view.magnitude and view.power
+    finally:
+        plt.close(fig)
+
+
+@pytest.mark.parametrize(
+    ("extent", "location"),
+    (
+        ((0.0, 1.0, 0.0, 3.0), "right"),
+        ((0.0, 3.0, 0.0, 1.0), "bottom"),
+    ),
+)
+def test_field_plot_colorbar_follows_field_aspect_ratio(extent, location):
+    fig, ax = _plot_image(np.ones((2, 2)), extent=extent, colorbar=True, show=False)
+    try:
+        colorbar_ax = fig.axes[-1]
+        plot_bounds = ax.get_position()
+        colorbar_bounds = colorbar_ax.get_position()
+        if location == "right":
+            assert colorbar_bounds.x0 > plot_bounds.x1
+            assert colorbar_bounds.height > colorbar_bounds.width
+        else:
+            assert colorbar_bounds.y1 < plot_bounds.y0
+            assert colorbar_bounds.width > colorbar_bounds.height
     finally:
         plt.close(fig)
 


### PR DESCRIPTION
## Summary
- place colorbars to the right of tall and square field plots
- place colorbars below wide field plots
- reduce colorbar spacing and plot padding for a compact layout

## Testing
- uv run --no-active --extra dev --extra test --python 3.11 python -m pytest tests/integration/test_simulation_plotting.py -q
- uv run --no-active --extra dev --extra test --python 3.11 ruff check beamz/analysis/plotting.py tests/integration/test_simulation_plotting.py
- uv run --no-active --extra dev --extra test --python 3.11 ruff format --check beamz/analysis/plotting.py tests/integration/test_simulation_plotting.py