### PR TITLE
Render face-on monitors as translucent rectangles

### DIFF
--- a/beamz/analysis/plotting.py
+++ b/beamz/analysis/plotting.py
@@ -716,6 +716,33 @@ def _draw_device_slice_overlay(ax, device, *, normal, origin, color, source):
         return
     axis, center, size, direction = geometry
     vertical, horizontal = _PLANE_AXES[normal]
+    if not source and axis == normal:
+        # A monitor whose plane is parallel to the displayed cross section is
+        # best represented by its full footprint, rather than the two center
+        # lines used for edge-on devices.
+        from matplotlib.patches import Rectangle
+
+        origin_by_axis = dict(zip(("x", "y", "z"), map(float, origin), strict=True))
+        indices = {"x": 0, "y": 1, "z": 2}
+        horizontal_index = indices[horizontal]
+        vertical_index = indices[vertical]
+        lower = (
+            (center[horizontal_index] - 0.5 * size[horizontal_index])
+            - origin_by_axis[horizontal],
+            (center[vertical_index] - 0.5 * size[vertical_index])
+            - origin_by_axis[vertical],
+        )
+        rectangle = Rectangle(
+            tuple(value / _UM for value in lower),
+            size[horizontal_index] / _UM,
+            size[vertical_index] / _UM,
+            facecolor=color,
+            edgecolor=color,
+            alpha=0.25,
+            linewidth=2.0,
+        )
+        ax.add_patch(rectangle)
+        return rectangle
     if axis == horizontal:
         segments = [(False, vertical, horizontal, True)]
     elif axis == vertical:

--- a/tests/integration/test_simulation_plotting.py
+++ b/tests/integration/test_simulation_plotting.py
@@ -125,6 +125,41 @@ def test_3d_simulation_plot_uses_tidy_layout_cross_sections():
         plt.close(fig)
 
 
+def test_3d_simulation_plot_renders_face_on_monitor_as_translucent_rectangle():
+    design = bz.Design(background=bz.Material(2.25))
+    monitor = bz.FluxMonitor(
+        center=(0.0, 0.0, 0.0),
+        size=(1.0 * bz.um, 0.8 * bz.um, 0.0),
+        freqs=[bz.LIGHT_SPEED / (1.55 * bz.um)],
+        name="top_view_flux",
+    )
+    sim = bz.Simulation(
+        domain=(4.0 * bz.um, 4.0 * bz.um, 2.0 * bz.um),
+        design=design,
+        monitors=[monitor],
+        boundaries=[bz.PML(thickness=0.5 * bz.um)],
+        resolution=0.5 * bz.um,
+        time=np.array([0.0, 1e-15]),
+    )
+
+    fig, axes = sim.plot(z=0.0, y=0.0, show=False)
+
+    try:
+        monitor_patches = [
+            patch
+            for patch in axes[0].patches
+            if to_hex(patch.get_edgecolor()) == "#ff9800"
+        ]
+        assert len(monitor_patches) == 1
+        patch = monitor_patches[0]
+        assert patch.get_width() == pytest.approx(1.0)
+        assert patch.get_height() == pytest.approx(0.8)
+        assert to_hex(patch.get_facecolor()) == "#ff9800"
+        assert patch.get_alpha() == pytest.approx(0.25)
+    finally:
+        plt.close(fig)
+
+
 def test_3d_layout_plot_uses_antialiased_polygon_sections_without_compiling(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary

- render monitors facing a 3D cross-section viewer as translucent, color-matched rectangles with borders
- retain line overlays for edge-on monitors and sources
- cover the face-on projection in the simulation plotting integration tests

Closes #217

## Validation

- `uv run --extra test pytest tests/integration/test_simulation_plotting.py -q`
- `uv run --extra lint ruff check beamz/analysis/plotting.py tests/integration/test_simulation_plotting.py`