### PR TITLE
Fix horizontal field colorbar label overlap

### DIFF
--- a/beamz/analysis/plotting.py
+++ b/beamz/analysis/plotting.py
@@ -1757,7 +1757,8 @@ def _add_field_colorbar(fig, ax, image, **kwargs):
         ax=ax,
         location="bottom",
         fraction=0.075,
-        pad=0.08,
+        # Keep the colorbar clear of the x-axis label after tight_layout().
+        pad=0.2,
         aspect=35,
         **kwargs,
     )

--- a/tests/integration/test_simulation_plotting.py
+++ b/tests/integration/test_simulation_plotting.py
@@ -59,6 +59,11 @@ def test_field_plot_colorbar_follows_field_aspect_ratio(extent, location):
         else:
             assert colorbar_bounds.y1 < plot_bounds.y0
             assert colorbar_bounds.width > colorbar_bounds.height
+            fig.canvas.draw()
+            renderer = fig.canvas.get_renderer()
+            assert not ax.xaxis.label.get_window_extent(renderer).overlaps(
+                colorbar_ax.get_tightbbox(renderer)
+            )
     finally:
         plt.close(fig)
 


### PR DESCRIPTION
## Summary
- reserve vertical space between horizontal field colorbars and x-axis labels
- add a rendered-bounds regression test for the bottom colorbar layout

Closes #219

## Tests
- `uv run --no-active python -m pytest tests/integration/test_simulation_plotting.py -q`
- `uv run --extra lint --no-active ruff check beamz/analysis/plotting.py tests/integration/test_simulation_plotting.py`
- `uv run --extra lint --no-active ruff format --check beamz/analysis/plotting.py tests/integration/test_simulation_plotting.py`